### PR TITLE
Added custom loot bags to NPC templates

### DIFF
--- a/0-XNPCCore/Config/Localization.txt
+++ b/0-XNPCCore/Config/Localization.txt
@@ -1,191 +1,217 @@
-Key,English,French,japanese
-MechFactionSchematic,"Master of disguse","Maitre de l'écoeurement","変装の名人"
-VaultDwellersFactionSchematic,"Master of disguse","Maitre de l'écoeurement","変装の名人"
-RedteamFactionSchematic,"Master of disguse","Maitre de l'écoeurement","変装の名人"
-BlueteamFactionSchematic,"Master of disguse","Maitre de l'écoeurement","変装の名人"
-GreenteamFactionSchematic,"Master of disguse","Maitre de l'écoeurement","変装の名人"
-MechFactionSchematicDesc,"Read this to switch over to the bandit faction!","Lisez ceci pour basculer dans la faction des Mech!","派閥変更・メカ"
-VaultDwellersFactionSchematicDesc,"Read this to switch over to the undead faction!","Lisez ceci pour basculer dans la faction des VaultDwellers!","派閥変更・ボルト住人"
-RedteamFactionSchematicDesc,"Read this to switch over to the Red team!","Lisez ceci pour basculer dans la faction Redteam!","チーム変更・赤"
-BlueteamFactionSchematicDesc,"Read this to switch over to the Blue team!","Lisez ceci pour basculer dans la faction Blue team!","チーム変更・青"
-GreenteamFactionSchematicDesc,"Read this to switch over to the Green Team!","Lisez ceci pour basculer dans la faction Green Team!","チーム変更・緑"
-MechPositiveFactionSchematic,"Peace and Love to the Mechs","","ピース&ラブ・メカ"
-MechPositiveFactionSchematicDesc,"Read this to spread the message of the mechs! Increase your standings with the mechs!","","メカの考えを拡散します。\n\nメカの信頼を得ます。"
-MechNegativeFactionSchematic,"Mechs: Unreliable! Untrustworthy!","","メカ: 頼りにならない！信用できない！"
-MechNegativeFactionSchematicDesc,"Read this to spread lies and fake news about the mechs! Decrease your standings with the mechs!","","メカのデマや悪い噂を拡散します。\n\nメカの信頼を失います。"
-VaultPositiveFactionSchematic,"Peace and Love to the Vault","","ピース&ラブ・ボルト"
-VaultPositiveFactionSchematicDesc,"Read this to spread the message of the vault! Increase your standings with the vault!","","ボルトの考えを拡散します。\n\nボルトの信頼を得ます。"
-VaultNegativeFactionSchematic,"The Vault: Unreliable! Untrustworthy!","","ボルト: 頼りにならない！信用できない！"
-VaultNegativeFactionSchematicDesc,"Read this to spread lies and fake news about the vault! Decrease your standings with the vault!","","ボルトのデマや悪い噂を拡散します。\n\nボルトの信頼を失います。"
-RedteamPositiveFactionSchematic,"Peace and Love to the Redteam","","ピース&ラブ・赤チーム"
-RedteamPositiveFactionSchematicDesc,"Read this to spread the message of the Redteam! Increase your standings with the Redteam!","","赤チームの考えを拡散します。\n\n赤チームの信頼を得ます。"
-RedteamNegativeFactionSchematic,"The Redteam: Unreliable! Untrustworthy!","","赤チーム: 頼りにならない！信用できない！"
-RedteamNegativeFactionSchematicDesc,"Read this to spread lies and fake news about the Redteam! Decrease your standings with the Redteam!","","赤チームのデマや悪い噂を拡散します。\n\n赤チームの信頼を失います。"
-BlueteamPositiveFactionSchematic,"Peace and Love to the Blueteam","","ピース&ラブ・青チーム"
-BlueteamPositiveFactionSchematicDesc,"Read this to spread the message of the Blueteam! Increase your standings with the Blueteam!","","青チームの考えを拡散します。\n\n青チームの信頼を得ます。"
-BlueteamNegativeFactionSchematic,"The Blueteam: Unreliable! Untrustworthy!","","青チーム: 頼りにならない！信用できない！"
-BlueteamNegativeFactionSchematicDesc,"Read this to spread lies and fake news about the Blueteam! Decrease your standings with the Blueteam!","","青チームのデマや悪い噂を拡散します。\n\n青チームの信頼を失います。"
-GreenteamPositiveFactionSchematic,"Peace and Love to the Greenteam","","ピース&ラブ・緑チーム"
-GreenteamPositiveFactionSchematicDesc,"Read this to spread the message of the Greenteam! Increase your standings with the Greenteam!","","緑チームの考えを拡散します。\n\n緑チームの信頼を得ます。"
-GreenteamNegativeFactionSchematic,"The Greenteam: Unreliable! Untrustworthy!","","緑チーム: 頼りにならない！信用できない！"
-GreenteamNegativeFactionSchematicDesc,"Read this to spread lies and fake news about the Greenteam! Decrease your standings with the Greenteam!","","緑チームのデマや悪い噂を拡散します。\n\n緑チームの信頼を失います。"
+Key,File,Type,UsedInMainMenu,NoTranslate,english,Context / Alternate Text,german,spanish,french,italian,japanese,koreana,polish,brazilian,russian,turkish,schinese,tchinese
+MechFactionSchematic,items,Item,,,Master of disguse,,,,Maitre de l'écoeurement,,変装の名人,,,,,,,
+VaultDwellersFactionSchematic,items,Item,,,Master of disguse,,,,Maitre de l'écoeurement,,変装の名人,,,,,,,
+RedteamFactionSchematic,items,Item,,,Master of disguse,,,,Maitre de l'écoeurement,,変装の名人,,,,,,,
+BlueteamFactionSchematic,items,Item,,,Master of disguse,,,,Maitre de l'écoeurement,,変装の名人,,,,,,,
+GreenteamFactionSchematic,items,Item,,,Master of disguse,,,,Maitre de l'écoeurement,,変装の名人,,,,,,,
+MechFactionSchematicDesc,items,Item,,,Read this to switch over to the bandit faction!,,,,Lisez ceci pour basculer dans la faction des Mech!,,派閥変更・メカ,,,,,,,
+VaultDwellersFactionSchematicDesc,items,Item,,,Read this to switch over to the undead faction!,,,,Lisez ceci pour basculer dans la faction des VaultDwellers!,,派閥変更・ボルト住人,,,,,,,
+RedteamFactionSchematicDesc,items,Item,,,Read this to switch over to the Red team!,,,,Lisez ceci pour basculer dans la faction Redteam!,,チーム変更・赤,,,,,,,
+BlueteamFactionSchematicDesc,items,Item,,,Read this to switch over to the Blue team!,,,,Lisez ceci pour basculer dans la faction Blue team!,,チーム変更・青,,,,,,,
+GreenteamFactionSchematicDesc,items,Item,,,Read this to switch over to the Green Team!,,,,Lisez ceci pour basculer dans la faction Green Team!,,チーム変更・緑,,,,,,,
+MechPositiveFactionSchematic,items,Item,,,Peace and Love to the Mechs,,,,,,ピース&ラブ・メカ,,,,,,,
+MechPositiveFactionSchematicDesc,items,Item,,,Read this to spread the message of the mechs! Increase your standings with the mechs!,,,,,,メカの考えを拡散します。\n\nメカの信頼を得ます。,,,,,,,
+MechNegativeFactionSchematic,items,Item,,,Mechs: Unreliable! Untrustworthy!,,,,,,メカ: 頼りにならない！信用できない！,,,,,,,
+MechNegativeFactionSchematicDesc,items,Item,,,Read this to spread lies and fake news about the mechs! Decrease your standings with the mechs!,,,,,,メカのデマや悪い噂を拡散します。\n\nメカの信頼を失います。,,,,,,,
+VaultPositiveFactionSchematic,items,Item,,,Peace and Love to the Vault,,,,,,ピース&ラブ・ボルト,,,,,,,
+VaultPositiveFactionSchematicDesc,items,Item,,,Read this to spread the message of the vault! Increase your standings with the vault!,,,,,,ボルトの考えを拡散します。\n\nボルトの信頼を得ます。,,,,,,,
+VaultNegativeFactionSchematic,items,Item,,,The Vault: Unreliable! Untrustworthy!,,,,,,ボルト: 頼りにならない！信用できない！,,,,,,,
+VaultNegativeFactionSchematicDesc,items,Item,,,Read this to spread lies and fake news about the vault! Decrease your standings with the vault!,,,,,,ボルトのデマや悪い噂を拡散します。\n\nボルトの信頼を失います。,,,,,,,
+RedteamPositiveFactionSchematic,items,Item,,,Peace and Love to the Redteam,,,,,,ピース&ラブ・赤チーム,,,,,,,
+RedteamPositiveFactionSchematicDesc,items,Item,,,Read this to spread the message of the Redteam! Increase your standings with the Redteam!,,,,,,赤チームの考えを拡散します。\n\n赤チームの信頼を得ます。,,,,,,,
+RedteamNegativeFactionSchematic,items,Item,,,The Redteam: Unreliable! Untrustworthy!,,,,,,赤チーム: 頼りにならない！信用できない！,,,,,,,
+RedteamNegativeFactionSchematicDesc,items,Item,,,Read this to spread lies and fake news about the Redteam! Decrease your standings with the Redteam!,,,,,,赤チームのデマや悪い噂を拡散します。\n\n赤チームの信頼を失います。,,,,,,,
+BlueteamPositiveFactionSchematic,items,Item,,,Peace and Love to the Blueteam,,,,,,ピース&ラブ・青チーム,,,,,,,
+BlueteamPositiveFactionSchematicDesc,items,Item,,,Read this to spread the message of the Blueteam! Increase your standings with the Blueteam!,,,,,,青チームの考えを拡散します。\n\n青チームの信頼を得ます。,,,,,,,
+BlueteamNegativeFactionSchematic,items,Item,,,The Blueteam: Unreliable! Untrustworthy!,,,,,,青チーム: 頼りにならない！信用できない！,,,,,,,
+BlueteamNegativeFactionSchematicDesc,items,Item,,,Read this to spread lies and fake news about the Blueteam! Decrease your standings with the Blueteam!,,,,,,青チームのデマや悪い噂を拡散します。\n\n青チームの信頼を失います。,,,,,,,
+GreenteamPositiveFactionSchematic,items,Item,,,Peace and Love to the Greenteam,,,,,,ピース&ラブ・緑チーム,,,,,,,
+GreenteamPositiveFactionSchematicDesc,items,Item,,,Read this to spread the message of the Greenteam! Increase your standings with the Greenteam!,,,,,,緑チームの考えを拡散します。\n\n緑チームの信頼を得ます。,,,,,,,
+GreenteamNegativeFactionSchematic,items,Item,,,The Greenteam: Unreliable! Untrustworthy!,,,,,,緑チーム: 頼りにならない！信用できない！,,,,,,,
+GreenteamNegativeFactionSchematicDesc,items,Item,,,Read this to spread lies and fake news about the Greenteam! Decrease your standings with the Greenteam!,,,,,,緑チームのデマや悪い噂を拡散します。\n\n緑チームの信頼を失います。,,,,,,,
 
+npcNurseEmptyHand,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseClub,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseKnife,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseAxe,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseSpear,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseBat,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseMachete,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseSMG,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseM60,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNursePipePistol,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNursePistol,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseDPistol,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNursePipeMG,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseAK47,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseTRifle,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNursePipeRifle,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseHRifle,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseSRifle,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNursePipeShotgun,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNursePShotgun,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseAShotgun,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseXBow,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseLBow,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcNurseRocketL,entityclasses,Entity,,,Nurse,,,,L’infirmière,,ナース,,,,,,,
+npcHarleyEmptyHand,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyBMEmptyHand,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyClub,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyKnife,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyAxe,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleySpear,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyBat,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyMachete,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleySMG,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyM60,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyPipePistol,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyPistol,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyDPistol,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyPipeMG,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyAK47,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyTRifle,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyPipeRifle,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyHRifle,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyPipeShotgun,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyPShotgun,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyAShotgun,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyXBow,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyLBow,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcHarleyRocketL,entityclasses,Entity,,,Harley,,,,Harley,,ハーレー,,,,,,,
+npcBakerEmptyHand,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerClub,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerKnife,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerAxe,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerSpear,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerBat,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerMachete,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerSMG,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerM60,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerPipePistol,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerPistol,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerDPistol,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerPipeMG,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerAK47,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerTRifle,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerPipeRifle,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerHRifle,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerSRifle,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerPipeShotgun,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerPShotgun,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerAShotgun,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerXBow,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerLBow,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcBakerRocketL,entityclasses,Entity,,,Baker,,,,Le boulanger,,ベーカー,,,,,,,
+npcAnimalFox,entityclasses,Entity,,,Fox,,,,Renard,,キツネ,,,,,,,
+animalFox,entityclasses,Entity,,,Fox,,,,Renard,,キツネ,,,,,,,
+zombieFemaleTutorial,entityclasses,Entity,,,DeadGirl,,,,Fille morte,,死んだ女の子,,,,,,,
+zombieFemaleTutorialFeral,entityclasses,Entity,,,DeadGirl,,,,Fille morte,,死んだ女の子,,,,,,,
 
+start,Quest,Dialogs,,,Are you the undead?,,,,,,あなたはアンデッドですか？,,,,,,,
+statement_-1684104497,Quest,Dialogs,,,Maybe not but a bar of soap wouldn't kill ya none either.,,,,,,,,,,,,,
+responseID_1595140464,Quest,Dialogs,,,No I'm not dead yet.,,,,,,いいえ、まだ死んではいません。,,,,,,,
+response_-24413466,Quest,Dialogs,,,Gee thanks.,,,,,,ありがとうございます。,,,,,,,
+responseID_-307220871,Quest,Dialogs,,,Be safe friend.,,,,,,お気をつけて。,,,,,,,
 
-npcNurseEmptyHand,"Nurse","L’infirmière","ナース"
-npcNurseClub,"Nurse","L’infirmière","ナース"
-npcNurseKnife,"Nurse","L’infirmière","ナース"
-npcNurseAxe,"Nurse","L’infirmière","ナース"
-npcNurseSpear,"Nurse","L’infirmière","ナース"
-npcNurseBat,"Nurse","L’infirmière","ナース"
-npcNurseMachete,"Nurse","L’infirmière","ナース"
-npcNurseSMG,"Nurse","L’infirmière","ナース"
-npcNurseM60,"Nurse","L’infirmière","ナース"
-npcNursePipePistol,"Nurse","L’infirmière","ナース"
-npcNursePistol,"Nurse","L’infirmière","ナース"
-npcNurseDPistol,"Nurse","L’infirmière","ナース"
-npcNursePipeMG,"Nurse","L’infirmière","ナース"
-npcNurseAK47,"Nurse","L’infirmière","ナース"
-npcNurseTRifle,"Nurse","L’infirmière","ナース"
-npcNursePipeRifle,"Nurse","L’infirmière","ナース"
-npcNurseHRifle,"Nurse","L’infirmière","ナース"
-npcNurseSRifle,"Nurse","L’infirmière","ナース"
-npcNursePipeShotgun,"Nurse","L’infirmière","ナース"
-npcNursePShotgun,"Nurse","L’infirmière","ナース"
-npcNurseAShotgun,"Nurse","L’infirmière","ナース"
-npcNurseXBow,"Nurse","L’infirmière","ナース"
-npcNurseLBow,"Nurse","L’infirmière","ナース"
-npcNurseRocketL,"Nurse","L’infirmière","ナース"
-npcHarleyEmptyHand,"Harley","Harley","ハーレー"
-npcHarleyBMEmptyHand,"Harley","Harley","ハーレー"
-npcHarleyClub,"Harley","Harley","ハーレー"
-npcHarleyKnife,"Harley","Harley","ハーレー"
-npcHarleyAxe,"Harley","Harley","ハーレー"
-npcHarleySpear,"Harley","Harley","ハーレー"
-npcHarleyBat,"Harley","Harley","ハーレー"
-npcHarleyMachete,"Harley","Harley","ハーレー"
-npcHarleySMG,"Harley","Harley","ハーレー"
-npcHarleyM60,"Harley","Harley","ハーレー"
-npcHarleyPipePistol,"Harley","Harley","ハーレー"
-npcHarleyPistol,"Harley","Harley","ハーレー"
-npcHarleyDPistol,"Harley","Harley","ハーレー"
-npcHarleyPipeMG,"Harley","Harley","ハーレー"
-npcHarleyAK47,"Harley","Harley","ハーレー"
-npcHarleyTRifle,"Harley","Harley","ハーレー"
-npcHarleyPipeRifle,"Harley","Harley","ハーレー"
-npcHarleyHRifle,"Harley","Harley","ハーレー"
-npcHarleyPipeShotgun,"Harley","Harley","ハーレー"
-npcHarleyPShotgun,"Harley","Harley","ハーレー"
-npcHarleyAShotgun,"Harley","Harley","ハーレー"
-npcHarleyXBow,"Harley","Harley","ハーレー"
-npcHarleyLBow,"Harley","Harley","ハーレー"
-npcHarleyRocketL,"Harley","Harley","ハーレー"
-npcBakerEmptyHand,"Baker","Le boulanger","ベーカー"
-npcBakerClub,"Baker","Le boulanger","ベーカー"
-npcBakerKnife,"Baker","Le boulanger","ベーカー"
-npcBakerAxe,"Baker","Le boulanger","ベーカー"
-npcBakerSpear,"Baker","Le boulanger","ベーカー"
-npcBakerBat,"Baker","Le boulanger","ベーカー"
-npcBakerMachete,"Baker","Le boulanger","ベーカー"
-npcBakerSMG,"Baker","Le boulanger","ベーカー"
-npcBakerM60,"Baker","Le boulanger","ベーカー"
-npcBakerPipePistol,"Baker","Le boulanger","ベーカー"
-npcBakerPistol,"Baker","Le boulanger","ベーカー"
-npcBakerDPistol,"Baker","Le boulanger","ベーカー"
-npcBakerPipeMG,"Baker","Le boulanger","ベーカー"
-npcBakerAK47,"Baker","Le boulanger","ベーカー"
-npcBakerTRifle,"Baker","Le boulanger","ベーカー"
-npcBakerPipeRifle,"Baker","Le boulanger","ベーカー"
-npcBakerHRifle,"Baker","Le boulanger","ベーカー"
-npcBakerSRifle,"Baker","Le boulanger","ベーカー"
-npcBakerPipeShotgun,"Baker","Le boulanger","ベーカー"
-npcBakerPShotgun,"Baker","Le boulanger","ベーカー"
-npcBakerAShotgun,"Baker","Le boulanger","ベーカー"
-npcBakerXBow,"Baker","Le boulanger","ベーカー"
-npcBakerLBow,"Baker","Le boulanger","ベーカー"
-npcBakerRocketL,"Baker","Le boulanger","ベーカー"
-npcAnimalFox,"Fox","Renard","キツネ"
-animalFox,"Fox","Renard","キツネ"
-zombieFemaleTutorial,"DeadGirl","Fille morte","死んだ女の子"
-zombieFemaleTutorialFeral,"DeadGirl","Fille morte","死んだ女の子"
+start,Quest,Dialogs,,,Hello there,,,,,,こんにちは,,,,,,,
+statement_-1333722013,Quest,Dialogs,,,Im just a farmer type guy,,,,,,私は農夫です。,,,,,,,
+statement_1334552027,Quest,Dialogs,,,"Naz, funny name eh?",,,,,,ナズ、変な名前でしょ？,,,,,,,
+responseID_-1128936168,Quest,Dialogs,,,Tell me about yourself,,,,,,あなたの事をおしえてください。,,,,,,,
+responseID_-1290029400,Quest,Dialogs,,,Whats this place called?,,,,,,この場所の名前は何ですか？,,,,,,,
+responseID_1101680756,Quest,Dialogs,,,OK Bye,,,,,,分かりました、さようなら,,,,,,,
 
-"start","Are you the undead?",,"あなたはアンデッドですか？"
-"statement_-1684104497","Maybe not but a bar of soap wouldn't kill ya none either.",
-"responseID_1595140464","No I'm not dead yet.",,"いいえ、まだ死んではいません。"
-"response_-24413466","Gee thanks.",,"ありがとうございます。"
-"responseID_-307220871","Be safe friend.",,"お気をつけて。"
+itemNPCModHelp,items,Item,,,NPC Action: Help,,,,Action PNJ: Aide,,NPCアクション： 手助け,,,,,,,
+itemNPCModStop,items,Item,,,NPC Action: Stop,,,,Action PNJ: Arrêt,,NPCアクション： 停止,,,,,,,
+itemNPCModMode,items,Item,,,NPC Action: Mode,,,,Action PNJ: Mode,,NPCアクション： モード,,,,,,,
 
-"start","Hello there",,"こんにちは"
-"statement_-1333722013","Im just a farmer type guy",,"私は農夫です。"
-"statement_1334552027","Naz, funny name eh?",,"ナズ、変な名前でしょ？"
-"responseID_-1128936168","Tell me about yourself",,"あなたの事をおしえてください。"
-"responseID_-1290029400","Whats this place called?",,"この場所の名前は何ですか？"
-"responseID_1101680756","OK Bye",,"分かりました、さようなら"
+buffNPCModHaltDisplayName,items,Item,,,Halt,,,,Arrêter,,,,,,,,,
+buffNPCModHaltDisplayDesc,items,Item,,,"While in either Threat or Full Control Mode, your hired NPCs will not engage until you tell them to Resume",,,,"Tant que vos PNJs seront en mode de contrôle complet ou de menaces, ils n'initieront pas le combat tant que vous le leur disiez de Reprendre",,,,,,,,,
+buffNPCModResumeDisplayName,items,Item,,,Resume,,,,Reprendre,,,,,,,,,
+buffNPCModResumeDisplayDesc,items,Item,,,"While in either Threat or Full Control Mode, your hired NPCs will engage until you tell them to Halt",,,,"Tant que vos PNJs seront en mode de contrôle complet ou de menaces, ils initieront le combat tant que vous le leur disiez d'Arrêter",,,,,,,,,
+buffNPCModHuntingModeDisplayName,items,Item,,,Hunting Mode,,,,Mode de Chasse,,,,,,,,,
+buffNPCModHuntingModeDisplayDesc,items,Item,,,"While in this mode, your hired NPCs will engage with everything considered as hostile",,,,"Dans ce mode, vos PNJs embauchés initieront le combat avec tout ce qu'ils considèrent être hostile",,,,,,,,,
+buffNPCModThreatControlModeDisplayName,items,Item,,,Threat Control Mode,,,,Mode de contrôle des menaces,,,,,,,,,
+buffNPCModThreatControlModeDisplayDesc,items,Item,,,"While in this mode, your hired NPCs will not engage with hostile animals (including zombies animals), unless:\n • You attack\n • You get attacked and took damage",,,,"Dans ce mode, vos your PNJs embauchés n'initieront pas le combat avec des animaux hostiles (incluant les animaux zombies), à moins que:\n • Vous attaquiez\n • Vous vous fassiez attaquer et prenez du dommage",,,,,,,,,
+buffNPCModFullControlModeDisplayName,items,Item,,,Full Control Mode,,,,Mode de contrôle complet,,,,,,,,,
+buffNPCModFullControlModeDisplayDesc,items,Item,,,"While in this mode, your hired NPCs will not engage, unless:\n • You attack\n • You get attacked and took damage",,,,"Dans ce mode, vos your PNJs embauchés n'initieront pas le combat, à moins que:\n • Vous attaquiez\n • Vous vous fassiez attaquer et prenez du dommage",,,,,,,,,
 
-itemNPCModHelp,"NPC Action: Help","Action PNJ: Aide","NPCアクション： 手助け"
-itemNPCModStop,"NPC Action: Stop","Action PNJ: Arrêt","NPCアクション： 停止"
-itemNPCModMode,"NPC Action: Mode","Action PNJ: Mode","NPCアクション： モード"
+GenericNPC_start,Quest,Dialogs,,,"Hello friend, how can I help you?",,,,"Bonjour ami, comment puis-je vous aider?",,こんにちは友達、どのようにあなたを助けることができますか？,,,,,,,
+GenericNPC_Command Menu,Quest,Dialogs,,,Command Menu,,,,Menu de commandes,,コマンドメニュー,,,,,,,
+GenericNPC_Weapon Classes,Quest,Dialogs,,,Weapon Classes,,,,Classes d'armes,,武器クラス,,,,,,,
+GenericNPC_Melee Menu,Quest,Dialogs,,,Melee Weapons,,,,Armes de mêlée,,近接武器,,,,,,,
+GenericNPC_Pistol Menu,Quest,Dialogs,,,Pistols,,,,Pistolets,,ピストル,,,,,,,
+GenericNPC_Rifle Menu,Quest,Dialogs,,,Rifles,,,,Fusils,,ライフル,,,,,,,
+GenericNPC_ShotGun Menu,Quest,Dialogs,,,Shotguns,,,,Fusils à pompe,,ショットガン,,,,,,,
+GenericNPC_Other Menu,Quest,Dialogs,,,Other Weapons,,,,Autres armes,,その他の武器,,,,,,,
+GenericNPC_Hire,Quest,Dialogs,,,I am interested in hiring you.,,,,Je suis intéressé à vous embaucher.,,あなたを雇うことに興味があります。,,,,,,,
+GenericNPC_FollowMe,Quest,Dialogs,,,Follow me,,,,Suivez-moi,,私に従ってください,,,,,,,
+GenericNPC_Dump2Log,Quest,Dialogs,,,Dump Values to Log,,,,Vider les valeurs dans le journal,,ログに値をダンプする,,,,,,,
+GenericNPC_ShowMe,Quest,Dialogs,,,Show Me your inventory,,,,Montrez-moi votre inventaire,,あなたの在庫を見せてください,,,,,,,
+GenericNPC_StayHere,Quest,Dialogs,,,Stay where you are standing,,,,Restez où vous êtes debout,,立っている場所にとどまってください,,,,,,,
+GenericNPC_Wander,Quest,Dialogs,,,Patrol around here,,,,Patrouillez autour d'ici,,ここを巡回してください,,,,,,,
+GenericNPC_Patrol,Quest,Dialogs,,,Patrol your coded route,,,,Patrouillez votre itinéraire codé,,コード化されたルートを巡回してください,,,,,,,
+GenericNPC_GuardHere,Quest,Dialogs,,,Stay where I am standing,,,,Restez où je suis debout,,私が立っている場所にとどまってください,,,,,,,
+GenericNPC_GuardReturnHere,Quest,Dialogs,,,Guard and return to where I am standing,,,,Gardez et revenez où je suis debout,,私が立っている場所に戻って警備してください,,,,,,,
+GenericNPC_SetCode,Quest,Dialogs,,,Here is your Patrol Code,,,,Voici votre code de patrouille,,こちらがあなたの巡回コードです,,,,,,,
+GenericNPC_Loot,Quest,Dialogs,,,Loot around here,,,,Pillez autour d'ici,,ここで略奪してください,,,,,,,
+GenericNPC_Dismiss,Quest,Dialogs,,,Dismiss,,,,Congédier,,解雇する,,,,,,,
+GenericNPC_Pickup,Quest,Dialogs,,,Pick Me up!,,,,Ramassez-moi!,,私を拾ってください！,,,,,,,
+GenericNPC_Weapon Menu,Quest,Dialogs,,,Weapon Menu,,,,Menu des armes,,武器メニュー,,,,,,,
+GenericNPC_Melee,Quest,Dialogs,,,Melee Menu,,,,Menu de mêlée,,近接メニュー,,,,,,,
+GenericNPC_Pistols,Quest,Dialogs,,,Pistol Menu,,,,Menu des pistolets,,ピストルメニュー,,,,,,,
+GenericNPC_Rifles,Quest,Dialogs,,,Rifle Menu,,,,Menu des fusils,,ライフルメニュー,,,,,,,
+GenericNPC_ShotGuns,Quest,Dialogs,,,ShotGun Menu,,,,Menu des fusils à pompe,,ショットガンメニュー,,,,,,,
+GenericNPC_Others,Quest,Dialogs,,,Other Menu,,,,Autre menu,,その他のメニュー,,,,,,,
+GenericNPC_BareHands,Quest,Dialogs,,,Use BareHands,,,,Utilisez les mains nues,,素手を使う,,,,,,,
+GenericNPC_Club,Quest,Dialogs,,,Use Club,,,,Utilisez un gourdin,,クラブを使う,,,,,,,
+GenericNPC_Knife,Quest,Dialogs,,,Use Knife,,,,Utilisez un couteau,,ナイフを使う,,,,,,,
+GenericNPC_Bat,Quest,Dialogs,,,Use Bat,,,,Utilisez une batte,,バットを使う,,,,,,,
+GenericNPC_Spear,Quest,Dialogs,,,Use Spear,,,,Utilisez une lance,,スピアを使う,,,,,,,
+GenericNPC_Machete,Quest,Dialogs,,,Use Machete,,,,Utilisez une machette,,マチェットを使う,,,,,,,
+GenericNPC_Axe,Quest,Dialogs,,,Use Axe,,,,Utilisez une hache,,斧を使う,,,,,,,
+GenericNPC_SMG,Quest,Dialogs,,,Use SMG,,,,Utilisez un pistolet-mitrailleur,,SMGを使う,,,,,,,
+GenericNPC_PipePistol,Quest,Dialogs,,,Use PipePistol,,,,Utilisez un pistolet à tuyau,,パイプピストルを使う,,,,,,,
+GenericNPC_PipeShotgun,Quest,Dialogs,,,Use PipeShotgun,,,,Utilisez un fusil à pompe à tuyau,,パイプショットガンを使う,,,,,,,
+GenericNPC_PipeRifle,Quest,Dialogs,,,Use PipeRifle,,,,Utilisez un fusil à tuyau,,パイプライフルを使う,,,,,,,
+GenericNPC_PipeMG,Quest,Dialogs,,,Use PipeMachinegun,,,,Utilisez une mitrailleuse à tuyau,,パイプマシンガンを使う,,,,,,,
+GenericNPC_M60,Quest,Dialogs,,,Use M60,,,,Utilisez un M60,,M60を使う,,,,,,,
+GenericNPC_Pistol,Quest,Dialogs,,,Use Pistol,,,,Utilisez un pistolet,,ピストルを使う,,,,,,,
+GenericNPC_DPistol,Quest,Dialogs,,,Use DesertEagle,,,,Utilisez un DesertEagle,,デザートイーグルを使う,,,,,,,
+GenericNPC_AK47,Quest,Dialogs,,,Use AK47,,,,Utilisez un AK47,,AK47を使う,,,,,,,
+GenericNPC_TRifle,Quest,Dialogs,,,Use AssaultRifle,,,,Utilisez un fusil d'assaut,,アサルトライフルを使う,,,,,,,
+GenericNPC_HRifle,Quest,Dialogs,,,Use HuntingR,,,,Utilisez un fusil de chasse,,ハンティングライフルを使う,,,,,,,
+GenericNPC_SRifle,Quest,Dialogs,,,Use SniperRifle,,,,Utilisez un fusil de sniper,,スナイパーライフルを使う,,,,,,,
+GenericNPC_LBow,Quest,Dialogs,,,Use Longbow,,,,Utilisez un arc long,,ロングボウを使う,,,,,,,
+GenericNPC_XBow,Quest,Dialogs,,,Use Crossbow,,,,Utilisez une arbalète,,クロスボウを使う,,,,,,,
+GenericNPC_PShotgun,Quest,Dialogs,,,Use Shotgun,,,,Utilisez un fusil à pompe,,ショットガンを使う,,,,,,,
+GenericNPC_AShotgun,Quest,Dialogs,,,Use AutoShotgun,,,,Utilisez un fusil à pompe automatique,,オートショットガンを使う,,,,,,,
+GenericNPC_RLauncher,Quest,Dialogs,,,Use RLauncher,,,,Utilisez un lance-roquettes,,ロケットランチャーを使う,,,,,,,
+GenericNPC_done,Quest,Dialogs,,,Nevermind.,,,,Peu importe.,,気にしないでください。,,,,,,,
 
-buffNPCModHaltDisplayName,Halt,Arrêter,
-buffNPCModHaltDisplayDesc,"While in either Threat or Full Control Mode, your hired NPCs will not engage until you tell them to Resume","Tant que vos PNJs seront en mode de contrôle complet ou de menaces, ils n'initieront pas le combat tant que vous le leur disiez de Reprendre",
-buffNPCModResumeDisplayName,Resume,Reprendre,
-buffNPCModResumeDisplayDesc,"While in either Threat or Full Control Mode, your hired NPCs will engage until you tell them to Halt","Tant que vos PNJs seront en mode de contrôle complet ou de menaces, ils initieront le combat tant que vous le leur disiez d'Arrêter",
-buffNPCModHuntingModeDisplayName,Hunting Mode,Mode de Chasse,
-buffNPCModHuntingModeDisplayDesc,"While in this mode, your hired NPCs will engage with everything considered as hostile","Dans ce mode, vos PNJs embauchés initieront le combat avec tout ce qu'ils considèrent être hostile",
-buffNPCModThreatControlModeDisplayName,Threat Control Mode,Mode de contrôle des menaces,
-buffNPCModThreatControlModeDisplayDesc,"While in this mode, your hired NPCs will not engage with hostile animals (including zombies animals), unless:\n • You attack\n • You get attacked and took damage","Dans ce mode, vos your PNJs embauchés n'initieront pas le combat avec des animaux hostiles (incluant les animaux zombies), à moins que:\n • Vous attaquiez\n • Vous vous fassiez attaquer et prenez du dommage",
-buffNPCModFullControlModeDisplayName,Full Control Mode,Mode de contrôle complet,
-buffNPCModFullControlModeDisplayDesc,"While in this mode, your hired NPCs will not engage, unless:\n • You attack\n • You get attacked and took damage","Dans ce mode, vos your PNJs embauchés n'initieront pas le combat, à moins que:\n • Vous attaquiez\n • Vous vous fassiez attaquer et prenez du dommage",
-
-GenericNPC_start, "Hello friend, how can I help you?", "Bonjour ami, comment puis-je vous aider?", "こんにちは友達、どのようにあなたを助けることができますか？"
-GenericNPC_Command Menu, "Command Menu", "Menu de commandes", "コマンドメニュー"
-GenericNPC_Weapon Classes, "Weapon Classes", "Classes d'armes", "武器クラス"
-GenericNPC_Melee Menu, "Melee Weapons", "Armes de mêlée", "近接武器"
-GenericNPC_Pistol Menu, "Pistols", "Pistolets", "ピストル"
-GenericNPC_Rifle Menu, "Rifles", "Fusils", "ライフル"
-GenericNPC_ShotGun Menu, "Shotguns", "Fusils à pompe", "ショットガン"
-GenericNPC_Other Menu, "Other Weapons", "Autres armes", "その他の武器"
-GenericNPC_Hire, "I am interested in hiring you.", "Je suis intéressé à vous embaucher.", "あなたを雇うことに興味があります。"
-GenericNPC_FollowMe, "Follow me", "Suivez-moi", "私に従ってください"
-GenericNPC_Dump2Log, "Dump Values to Log", "Vider les valeurs dans le journal", "ログに値をダンプする"
-GenericNPC_ShowMe, "Show Me your inventory", "Montrez-moi votre inventaire", "あなたの在庫を見せてください"
-GenericNPC_StayHere, "Stay where you are standing", "Restez où vous êtes debout", "立っている場所にとどまってください"
-GenericNPC_Wander, "Patrol around here", "Patrouillez autour d'ici", "ここを巡回してください"
-GenericNPC_Patrol, "Patrol your coded route", "Patrouillez votre itinéraire codé", "コード化されたルートを巡回してください"
-GenericNPC_GuardHere, "Stay where I am standing", "Restez où je suis debout", "私が立っている場所にとどまってください"
-GenericNPC_GuardReturnHere, "Guard and return to where I am standing", "Gardez et revenez où je suis debout", "私が立っている場所に戻って警備してください"
-GenericNPC_SetCode, "Here is your Patrol Code", "Voici votre code de patrouille", "こちらがあなたの巡回コードです"
-GenericNPC_Loot, "Loot around here", "Pillez autour d'ici", "ここで略奪してください"
-GenericNPC_Dismiss, "Dismiss", "Congédier", "解雇する"
-GenericNPC_Pickup, "Pick Me up!", "Ramassez-moi!", "私を拾ってください！"
-GenericNPC_Weapon Menu, "Weapon Menu", "Menu des armes", "武器メニュー"
-GenericNPC_Melee, "Melee Menu", "Menu de mêlée", "近接メニュー"
-GenericNPC_Pistols, "Pistol Menu", "Menu des pistolets", "ピストルメニュー"
-GenericNPC_Rifles, "Rifle Menu", "Menu des fusils", "ライフルメニュー"
-GenericNPC_ShotGuns, "ShotGun Menu", "Menu des fusils à pompe", "ショットガンメニュー"
-GenericNPC_Others, "Other Menu", "Autre menu", "その他のメニュー"
-GenericNPC_BareHands, "Use BareHands", "Utilisez les mains nues", "素手を使う"
-GenericNPC_Club, "Use Club", "Utilisez un gourdin", "クラブを使う"
-GenericNPC_Knife, "Use Knife", "Utilisez un couteau", "ナイフを使う"
-GenericNPC_Bat, "Use Bat", "Utilisez une batte", "バットを使う"
-GenericNPC_Spear, "Use Spear", "Utilisez une lance", "スピアを使う"
-GenericNPC_Machete, "Use Machete", "Utilisez une machette", "マチェットを使う"
-GenericNPC_Axe, "Use Axe", "Utilisez une hache", "斧を使う"
-GenericNPC_SMG, "Use SMG", "Utilisez un pistolet-mitrailleur", "SMGを使う"
-GenericNPC_PipePistol, "Use PipePistol", "Utilisez un pistolet à tuyau", "パイプピストルを使う"
-GenericNPC_PipeShotgun, "Use PipeShotgun", "Utilisez un fusil à pompe à tuyau", "パイプショットガンを使う"
-GenericNPC_PipeRifle, "Use PipeRifle", "Utilisez un fusil à tuyau", "パイプライフルを使う"
-GenericNPC_PipeMG, "Use PipeMachinegun", "Utilisez une mitrailleuse à tuyau", "パイプマシンガンを使う"
-GenericNPC_M60, "Use M60", "Utilisez un M60", "M60を使う"
-GenericNPC_Pistol, "Use Pistol", "Utilisez un pistolet", "ピストルを使う"
-GenericNPC_DPistol, "Use DesertEagle", "Utilisez un DesertEagle", "デザートイーグルを使う"
-GenericNPC_AK47, "Use AK47", "Utilisez un AK47", "AK47を使う"
-GenericNPC_TRifle, "Use AssaultRifle", "Utilisez un fusil d'assaut", "アサルトライフルを使う"
-GenericNPC_HRifle, "Use HuntingR", "Utilisez un fusil de chasse", "ハンティングライフルを使う"
-GenericNPC_SRifle, "Use SniperRifle", "Utilisez un fusil de sniper", "スナイパーライフルを使う"
-GenericNPC_LBow, "Use Longbow", "Utilisez un arc long", "ロングボウを使う"
-GenericNPC_XBow, "Use Crossbow", "Utilisez une arbalète", "クロスボウを使う"
-GenericNPC_PShotgun, "Use Shotgun", "Utilisez un fusil à pompe", "ショットガンを使う"
-GenericNPC_AShotgun, "Use AutoShotgun", "Utilisez un fusil à pompe automatique", "オートショットガンを使う"
-GenericNPC_RLauncher, "Use RLauncher", "Utilisez un lance-roquettes", "ロケットランチャーを使う"
-GenericNPC_done, "Nevermind.", "Peu importe.", "気にしないでください。"
+EntityLootContainerNPC,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainer,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerClub,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerKnife,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerBat,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerAxe,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerSpear,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerMachete,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerPipePistol,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerPistol,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerDPistol,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerSMG,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerM60,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerAK47,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerPipeMG,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerTRifle,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerPipeRifle,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerHRifle,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerSRifle,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerPipeShotgun,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerPShotgun,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerAShotgun,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerLBow,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerXBow,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerRocketL,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerMech,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品
+EntityNPCLootContainerPistolHidden,entityclasses,Entity Info,,,Dropped Loot,,Fallengelassene Beute,Botín abandonado,Butin abandonné,Bottino caduto,落ちている略奪品,떨어진 약탈품,Upuszczony łup,Espólio caído,Выпавшие вещи,Düşürülmüş Ganimet,掉落的战利品,掉落戰利品

--- a/0-XNPCCore/Config/entityclasses.xml
+++ b/0-XNPCCore/Config/entityclasses.xml
@@ -4119,10 +4119,10 @@
 			<property name="LootListOnDeath" value="cntNPCPistol" />
 		</entity_class>
 		<!--
-            This is the loot container used by Mechs with "hidden pistols" (built-in weapons).
-            These entities shouldn't drop any weapons, but they may drop ammo or parts.
-            There are no NPC Core Mechs that use these weapons, but packs may have them.
-        -->
+			This is the loot container used by Mechs with "hidden pistols" (built-in weapons).
+			These entities shouldn't drop any weapons, but they may drop ammo or parts.
+			There are no NPC Core Mechs that use these weapons, but packs may have them.
+		-->
 		<entity_class name="EntityNPCLootContainerPistolHidden" extends="EntityLootContainerNPC">
 			<property name="HideInSpawnMenu" value="true" />
 			<property name="LootListOnDeath" value="cntNPCPistolHidden" />

--- a/0-XNPCCore/Config/entityclasses.xml
+++ b/0-XNPCCore/Config/entityclasses.xml
@@ -310,8 +310,8 @@
 			<property name="JumpMaxDistance" value="2.8, 3.9"/> 
 			<property name="Immunity" value="sickness;disease;wellness"/> 
 			<property name="ExperienceGain" value="600"/> 
-			<property name="LootDropProb" value="0.0"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>
+			<property name="LootDropProb" value="0.2" /> 
+			<property name="LootDropEntityClass" value="EntityNPCLootContainer" />
 			<!--<property name="LootDropEntityClass" value="EntityLootContainerNPC"/>-->
 			<!--<property name="MapIcon" value="ui_game_symbol_bullet_point"/> -->
 			<property name="Names" value="" />
@@ -735,6 +735,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1000" />
 			<property name="ExperienceGain" value="600"/> 
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerClub" />
 		</entity_class>
 		
 		<!-- Weapon template for bloodmoon  -->
@@ -757,6 +758,7 @@
 			<property name="Class" value="EntityBandit" /> 
 			<property name="HandItem" value="meleeNPCClubWood"/>
 			<property name="RightHandJointName" value="Club" />
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerClub" />
 		</entity_class>	
 		
 
@@ -788,6 +790,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="750" />
 			<property name="ExperienceGain" value="600"/> 
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerKnife" />
 		</entity_class>	
 		
 		<entity_class name="npcBMKnifeTemplate" extends="npcKnifeTemplate">
@@ -807,6 +810,7 @@
 			<property name="Class" value="EntityBandit" /> 
 			<property name="HandItem" value="meleeNPCKnife"/>
 			<property name="RightHandJointName" value="Knife" />
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerKnife" />
 		</entity_class>	
 		
 		<!-- Weapon template for advanced, hireable characters  -->
@@ -835,6 +839,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1000" />
 			<property name="ExperienceGain" value="600"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerBat" />
 		</entity_class>	
 		
 		<entity_class name="npcBMBatTemplate" extends="npcBatTemplate">
@@ -855,6 +860,7 @@
 			<property name="Class" value="EntityBandit" /> 
 			<property name="HandItem" value="meleeNPCBatWood"/>
 			<property name="RightHandJointName" value="Bat" />
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerBat" />
 		</entity_class>	
 		
 		
@@ -887,6 +893,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1000" />
 			<property name="ExperienceGain" value="600"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerAxe" />
 		</entity_class>		
 
 		<entity_class name="npcBMAxeTemplate" extends="npcAxeTemplate">
@@ -907,6 +914,7 @@
 			<property name="Class" value="EntityBandit" /> 
 			<property name="HandItem" value="meleeNPCAxe"/>
 			<property name="RightHandJointName" value="Axe" />
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerAxe" />
 		</entity_class>	
 
 		<!-- Weapon template for advanced, hireable characters  -->
@@ -935,6 +943,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1000" />
 			<property name="ExperienceGain" value="600"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerSpear" />
 		</entity_class>		
 		
 		<entity_class name="npcBMSpearTemplate" extends="npcSpearTemplate">
@@ -954,6 +963,7 @@
 			<property name="Class" value="EntityBandit" /> 
 			<property name="HandItem" value="meleeNPCSpear"/>
 			<property name="RightHandJointName" value="Spear" />
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerSpear" />
 		</entity_class>	
 
 		<!-- Weapon template for advanced, hireable characters  -->
@@ -982,6 +992,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1000" />
 			<property name="ExperienceGain" value="600"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerMachete" />
 		</entity_class>	
 		
 		<entity_class name="npcBMMacheteTemplate" extends="npcMacheteTemplate">
@@ -1001,6 +1012,7 @@
 			<property name="Class" value="EntityBandit" /> 
 			<property name="HandItem" value="meleeNPCMachete"/>
 			<property name="RightHandJointName" value="Machete" />
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerMachete" />
 		</entity_class>	
 
 		<!-- Weapon template for advanced, hireable characters  -->
@@ -1029,6 +1041,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1250" />
 			<property name="ExperienceGain" value="1000"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerPipePistol" />
 		</entity_class>	
 		
 		<entity_class name="npcBMPipePistolTemplate" extends="npcPipePistolTemplate">
@@ -1049,6 +1062,7 @@
 			<property name="HandItem" value="gunNPCPipePistol"/>
 			<property name="RightHandJointName" value="PipePistol" />
 			<property name="AITask-5" value="RangedAttackTarget" data="itemType=1;cooldown=4;duration=6;minRange=2;maxRange=15;unreachableRange=40"/>  <!-- set duration == rounds?  -->
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerPipePisol" />
 		</entity_class>	
 		
 		<entity_class name="npcBanditPipePistolTemplate2" extends="npcRanged2BanditTemplate"> <!--  EAI testing on PipePistol  -->
@@ -1060,6 +1074,7 @@
 			<property name="Class" value="EntityBandit" /> 
 			<property name="HandItem" value="gunNPCPipePistol"/>
 			<property name="RightHandJointName" value="PipePistol" />
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerPipePistol" />
 		</entity_class>	
 		
 
@@ -1089,6 +1104,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="2250" />
 			<property name="ExperienceGain" value="1200"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerPistol" />
 		</entity_class>		
 		
 		<entity_class name="npcBMPistolTemplate" extends="npcPistolTemplate">
@@ -1126,6 +1142,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="2750" />
 			<property name="ExperienceGain" value="1400"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerDPistol" />
 		</entity_class>	
 
 		<entity_class name="npcBMDPistolTemplate" extends="npcDPistolTemplate">
@@ -1164,6 +1181,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="3250" />
 			<property name="ExperienceGain" value="1400"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerSMG" />
 		</entity_class>	
 		
 		<entity_class name="npcBMSMGTemplate" extends="npcSMGTemplate">
@@ -1202,6 +1220,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="3500" />
 			<property name="ExperienceGain" value="1400"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerM60" />
 		</entity_class>	
 		
 		<entity_class name="npcBMM60Template" extends="npcM60Template">
@@ -1238,6 +1257,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="3250" />
 			<property name="ExperienceGain" value="1200"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerAK47" />
 		</entity_class>
 		
 		<entity_class name="npcBMAK47Template" extends="npcAK47Template">
@@ -1274,6 +1294,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1750" />
 			<property name="ExperienceGain" value="1000"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerPipeMG" />
 		</entity_class>	
 
 		<entity_class name="npcBMPipeMGTemplate" extends="npcPipeMGTemplate">
@@ -1311,6 +1332,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="3500" />
 			<property name="ExperienceGain" value="1200"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerTRifle" />
 		</entity_class>	
 		
 		<entity_class name="npcBMTRifleTemplate" extends="npcTRifleTemplate">
@@ -1348,6 +1370,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1000" />
 			<property name="ExperienceGain" value="800"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerPipeRifle" />
         </entity_class>    
 
 		<entity_class name="npcBMPipeRifleTemplate" extends="npcPipeRifleTemplate">
@@ -1384,6 +1407,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1250" />
 			<property name="ExperienceGain" value="1000"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerHRifle" />
         </entity_class> 
 
  		<entity_class name="npcBMHRifleTemplate" extends="npcHRifleTemplate">
@@ -1420,6 +1444,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="3250" />
 			<property name="ExperienceGain" value="1400"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerSRifle" />
         </entity_class>  
 
 		<entity_class name="npcBMSRifleTemplate" extends="npcSRifleTemplate">
@@ -1456,6 +1481,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="1250" />
 			<property name="ExperienceGain" value="800"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerPipeShotgun" />
 		</entity_class> 
 
 		<entity_class name="npcBMPipeShotgunTemplate" extends="npcPipeShotgunTemplate">
@@ -1492,6 +1518,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="2250" />
 			<property name="ExperienceGain" value="1200"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerPShotgun" />
 		</entity_class> 
 		
 		<entity_class name="npcBMPShotgunTemplate" extends="npcPShotgunTemplate">
@@ -1528,6 +1555,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="3500" />
 			<property name="ExperienceGain" value="1400"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerAShotgun" />
 		</entity_class>
 
 		<entity_class name="npcBMAShotgunTemplate" extends="npcAShotgunTemplate">
@@ -1564,6 +1592,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="2000" />
 			<property name="ExperienceGain" value="800"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerLBow" />
 		</entity_class> 
 
 		<entity_class name="npcBMLBowTemplate" extends="npcLBowTemplate">
@@ -1600,6 +1629,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="2500" />
 			<property name="ExperienceGain" value="1000"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerXBow" />
 			<!-- For testing launcher version  -->
 			<!-- <property name="ItemsOnEnterGame.GameModeSurvival" value="gunNPCXBow,ammoNPCCrossbowBoltIron2"/>
 			<property name="ItemsOnEnterGame.GameModeSurvivalSP" value="gunNPCXBow,ammoNPCCrossbowBoltIron2"/>
@@ -1642,6 +1672,7 @@
 			<property name="HireCurrency" value="casinoCoin" />
 			<property name="HireCost" value="3000" />
 			<property name="ExperienceGain" value="1400"/>
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerRocketL" />
 		</entity_class>	
 
 		<entity_class name="npcBMRocketLTemplate" extends="npcRocketLTemplate">
@@ -2483,6 +2514,7 @@
 			<property name="Names" value="KITT,HK-47,ED-209,Clank,Johnny5,Roboto,Marvin,Robbie,Rosie,HAL9000,GLaDOS,Bender" />		
 			<property name="HireCurrency" value="carBattery" />
 			<property name="HireCost" value="1" />
+			<property name="LootDropEntityClass" value="EntityNPCLootContainerMech" />
 		</entity_class> 
 		
 		<entity_class name="NPCMechMeleeTemplate" extends="npcMechMeleeTemplate" > <!-- for backwards compatibility  -->
@@ -3161,7 +3193,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>
 			<!-- <property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> -->
 		</entity_class>	
 		
@@ -3197,7 +3228,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>
 		</entity_class>
 		
 		<entity_class name="npcHarleyKnife" extends="npcBanditKnifeTemplate"> 
@@ -3223,7 +3253,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>
 		</entity_class>	
 		
 		<entity_class name="npcHarleyBat" extends="npcBanditBatTemplate"> 
@@ -3249,7 +3278,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 		</entity_class>			
 	
 		<entity_class name="npcHarleyMachete" extends="npcBanditMacheteTemplate"> 
@@ -3275,7 +3303,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>
 		</entity_class>		
 
 
@@ -3302,7 +3329,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>
 		</entity_class>	
 		
 		<entity_class name="npcHarleySpear" extends="npcBanditSpearTemplate"> 
@@ -3328,7 +3354,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 		</entity_class>			
 		
 		<entity_class name="npcHarleyPipePistol" extends="npcPipePistolTemplate"> 
@@ -3356,7 +3381,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>	
 		
@@ -3383,7 +3407,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>	
 		
@@ -3410,7 +3433,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>				
 		
@@ -3437,7 +3459,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 			<property name="MaxViewAngle" value="270"/> 
 		</entity_class>	
@@ -3465,7 +3486,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>	
 		
@@ -3492,7 +3512,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>			
 		
@@ -3519,7 +3538,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>				
 		
@@ -3546,7 +3564,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>				
 
@@ -3573,7 +3590,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>
 		
@@ -3600,7 +3616,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>		
 		
@@ -3627,7 +3642,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>
 
@@ -3654,7 +3668,6 @@
 			<property name="SoundAttack" value="HarleyAttack" />
 			<property name="SoundSense" value="HarleySense" />
 			<property name="LootDropProb" value="0.2" />
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular" />
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>
 
@@ -3681,7 +3694,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
         </entity_class>   
 
@@ -3708,7 +3720,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
         </entity_class>   	
 		
@@ -3735,7 +3746,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class> 
 
@@ -3762,7 +3772,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>	
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>	
 		<entity_class name="npcHarleyRocketL" extends="npcRocketLTemplate"> 
@@ -3788,7 +3797,6 @@
 			<property name="SoundAttack" value="HarleyAttack"/>
 			<property name="SoundSense" value="HarleySense"/>
 			<property name="LootDropProb" value="0.2"/> 
-			<property name="LootDropEntityClass" value="EntityLootContainerRegular"/>
 			<property name="AIPackages" value="NPCModCoreNoChat, NPCModHostileMeleeBasic, NPCModHostileRangedBasic"/> 
 		</entity_class>	
 		<entity_class name="npcHarleyVomitHand" extends="npcMeleeTemplate"> <!-- testing -->
@@ -4049,7 +4057,7 @@
 		<entity_class name="EntityLootContainerNPC">
 			<property name="Class" value="EntityLootContainer"/>
 			<property name="UserSpawnType" value="Console"/>
-			<property name="Mesh" value="@:Entities/LootContainers/zpackPrefab.prefab"/>
+			<property name="Mesh" value="@:Entities/LootContainers/backpack_droppedPrefab.prefab" />
 			<property name="ModelType" value="Custom"/>
 			<property name="Prefab" value="Backpack"/>
 			<property name="Parent" value="Backpack"/>
@@ -4071,6 +4079,117 @@
 			<property name="LootListOnDeath" value="playerBackpack"/>
 			<property name="Faction" value="none"/>
 			<property name="NavObject" value="backpack" />
+		</entity_class>
+
+		<!-- Custom loot drop containers by weapon -->
+		<entity_class name="EntityNPCLootContainer" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCEmptyHand" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerClub" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCClub" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerKnife" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCKnife" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerBat" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCBat" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerAxe" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCAxe" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerSpear" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCSpear" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerMachete" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCMachete" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerPipePistol" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCPipePistol" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerPistol" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCPistol" />
+		</entity_class>
+		<!--
+            This is the loot container used by Mechs with "hidden pistols" (built-in weapons).
+            These entities shouldn't drop any weapons, but they may drop ammo or parts.
+            There are no NPC Core Mechs that use these weapons, but packs may have them.
+        -->
+		<entity_class name="EntityNPCLootContainerPistolHidden" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCPistolHidden" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerDPistol" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCDPistol" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerSMG" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCSMG" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerM60" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCM60" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerAK47" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCAK47" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerPipeMG" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCPipeMG" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerTRifle" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCTRifle" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerPipeRifle" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCPipeRifle" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerHRifle" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCHRifle" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerSRifle" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCSRifle" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerPipeShotgun" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCPipeShotgun" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerPShotgun" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCPShotgun" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerAShotgun" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCAShotgun" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerLBow" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCLBow" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerXBow" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCXBow" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerRocketL" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCRocketL" />
+		</entity_class>
+		<entity_class name="EntityNPCLootContainerMech" extends="EntityLootContainerNPC">
+			<property name="HideInSpawnMenu" value="true" />
+			<property name="LootListOnDeath" value="cntNPCMech" />
 		</entity_class>
 		
 		<!--  NPC and Dumb animals  -->	

--- a/0-XNPCCore/Config/loot.xml
+++ b/0-XNPCCore/Config/loot.xml
@@ -3,5 +3,434 @@
 	   <!--<append xpath="/lootcontainers/lootgroup[@name='groupMedicalRare']">
 			<item name="drugHealInfectedCharacter" />
 	   </append> -->
+	
+	<!--
+        NPC lootgroups - mainly weapon groups that can spawn weapons, parts, or ammo.
+    -->
+	<insertBefore xpath="/lootcontainers/lootcontainer[1]">
+		<!-- NPC common backpack items loot groups - tiered medical, food, drink -->
+		<lootgroup name="groupNPCMedical" count="1">
+			<item group="groupMedicalSmall01" loot_prob_template="ProbT0" />
+			<item group="groupMedicalMed01" loot_prob_template="ProbT1" />
+			<item group="groupMedicalLarge01" loot_prob_template="ProbT1Cap" />
+		</lootgroup>
+		<lootgroup name="groupNPCFood" count="1">
+			<item group="groupFoodSmall01" loot_prob_template="ProbT0" />
+			<item group="groupFoodMed01" loot_prob_template="ProbT1" />
+			<item group="groupFoodLarge01" loot_prob_template="ProbT1Cap" />
+		</lootgroup>
+		<lootgroup name="groupNPCDrinks" count="1">
+			<item group="groupDrinksSmall01" loot_prob_template="ProbT0" />
+			<item group="groupDrinksMed01" loot_prob_template="ProbT1" />
+			<item group="groupDrinksLarge01" loot_prob_template="ProbT1Cap" />
+		</lootgroup>
+		<lootgroup name="groupNPCBackpacks">
+			<item group="groupNPCMedical" loot_prob_template="low" />
+			<item group="groupNPCFood" loot_prob_template="medLow" />
+			<item group="groupNPCDrinks" loot_prob_template="medLow" />
+		</lootgroup>
+		<!--
+            NPC Core Mechs can be harvested for resources, so don't include these items:
+            * resourceMechanicalParts
+            * resourceScrapIron
+            * resourceElectricParts
+            * resourceScrapPolymers
+        -->
+		<lootgroup name="groupNPCMechBackpacks" count="1,3">
+			<item name="gunBotRoboticsParts" count="1,2" loot_prob_template="high" />
+			<item name="resourceAcid" count="1" loot_prob_template="veryLow" />
+			<item name="resourceForgedIron" count="1,5" loot_prob_template="low" />
+			<item name="resourceForgedSteel" count="1,3" loot_prob_template="veryLow" />
+			<item name="resourceHeadlight" count="1,2" loot_prob_template="med" />
+			<item name="resourceMetalPipe" count="1,5" loot_prob_template="med" />
+			<item name="resourceOil" count="1,5" loot_prob_template="med" />
+			<item name="resourceSpring" count="1,2" loot_prob_template="med" />
+			<item group="groupRareAutomotive" count="1" loot_prob_template="low" />
+		</lootgroup>
+
+		<!-- NPC ammo loot groups, scaled. -->
+		<lootgroup name="groupNPCAmmo9mmBullet">
+			<item name="ammo9mmBulletBall" loot_prob_template="ProbT0" count="15,30" />
+			<item name="ammo9mmBulletBall" loot_prob_template="ProbT1" count="20,40" />
+			<item name="ammo9mmBulletBall" loot_prob_template="ProbT2" count="30,60" />
+			<item name="ammo9mmBulletBall" loot_prob_template="ProbT3" count="45,90" />
+			<item name="ammo9mmBulletAP" loot_prob_template="ProbT2" count="15,30" />
+			<item name="ammo9mmBulletAP" loot_prob_template="ProbT3" count="20,40" />
+			<item name="ammo9mmBulletHP" loot_prob_template="ProbT2" count="15,30" />
+			<item name="ammo9mmBulletHP" loot_prob_template="ProbT3" count="20,40" />
+		</lootgroup>
+		<lootgroup name="groupNPCAmmo762mmBullet">
+			<item name="ammo762mmBulletBall" loot_prob_template="ProbT0" count="6,12" />
+			<item name="ammo762mmBulletBall" loot_prob_template="ProbT1" count="8,17" />
+			<item name="ammo762mmBulletBall" loot_prob_template="ProbT2" count="12,25" />
+			<item name="ammo762mmBulletBall" loot_prob_template="ProbT3" count="18,37" />
+			<item name="ammo762mmBulletAP" loot_prob_template="ProbT2" count="8,19" />
+			<item name="ammo762mmBulletAP" loot_prob_template="ProbT3" count="12,25" />
+			<item name="ammo762mmBulletHP" loot_prob_template="ProbT2" count="8,19" />
+			<item name="ammo762mmBulletHP" loot_prob_template="ProbT3" count="12,25" />
+		</lootgroup>
+		<lootgroup name="groupNPCAmmo44MagnumBullet">
+			<item name="ammo44MagnumBulletBall" loot_prob_template="ProbT0" count="6,14" />
+			<item name="ammo44MagnumBulletBall" loot_prob_template="ProbT1" count="8,19" />
+			<item name="ammo44MagnumBulletBall" loot_prob_template="ProbT2" count="12,29" />
+			<item name="ammo44MagnumBulletBall" loot_prob_template="ProbT3" count="18,44" />
+			<item name="ammo44MagnumBulletAP" loot_prob_template="ProbT2" count="6,14" />
+			<item name="ammo44MagnumBulletAP" loot_prob_template="ProbT3" count="8,19" />
+			<item name="ammo44MagnumBulletHP" loot_prob_template="ProbT2" count="6,14" />
+			<item name="ammo44MagnumBulletHP" loot_prob_template="ProbT3" count="8,19" />
+		</lootgroup>
+		<lootgroup name="groupNPCAmmoShotgun">
+			<item name="ammoShotgunShell" loot_prob_template="ProbT0" count="3,4" />
+			<item name="ammoShotgunShell" loot_prob_template="ProbT1" count="5,7" />
+			<item name="ammoShotgunShell" loot_prob_template="ProbT2" count="8,12" />
+			<item name="ammoShotgunShell" loot_prob_template="ProbT3" count="12,19" />
+			<item name="ammoShotgunSlug" loot_prob_template="ProbT2" count="6,11" />
+			<item name="ammoShotgunSlug" loot_prob_template="ProbT3" count="8,16" />
+			<item name="ammoShotgunBreachingSlug" loot_prob_template="ProbT2" count="6,11" />
+			<item name="ammoShotgunBreachingSlug" loot_prob_template="ProbT3" count="8,16" />
+		</lootgroup>
+		<lootgroup name="groupNPCAmmoArrow">
+			<item name="ammoArrowStone" loot_prob_template="ProbT0" count="4,6" />
+			<item name="ammoArrowStone" loot_prob_template="ProbT1" count="8,12" />
+			<item name="ammoArrowStone" loot_prob_template="ProbT2" count="16,24" />
+			<item name="ammoArrowIron" loot_prob_template="ProbT1" count="4,6" />
+			<item name="ammoArrowIron" loot_prob_template="ProbT2" count="8,12" />
+			<item name="ammoArrowIron" loot_prob_template="ProbT3" count="16,24" />
+			<item name="ammoArrowSteelAP" loot_prob_template="ProbT2" count="4,6" />
+			<item name="ammoArrowSteelAP" loot_prob_template="ProbT3" count="8,12" />
+		</lootgroup>
+		<lootgroup name="groupNPCAmmoCrossbowBolt">
+			<item name="ammoCrossbowBoltStone" loot_prob_template="ProbT0" count="4,6" />
+			<item name="ammoCrossbowBoltStone" loot_prob_template="ProbT1" count="8,12" />
+			<item name="ammoCrossbowBoltStone" loot_prob_template="ProbT2" count="16,24" />
+			<item name="ammoCrossbowBoltIron" loot_prob_template="ProbT1" count="4,6" />
+			<item name="ammoCrossbowBoltIron" loot_prob_template="ProbT2" count="8,12" />
+			<item name="ammoCrossbowBoltIron" loot_prob_template="ProbT3" count="16,24" />
+			<item name="ammoCrossbowBoltSteelAP" loot_prob_template="ProbT2" count="4,6" />
+			<item name="ammoCrossbowBoltSteelAP" loot_prob_template="ProbT3" count="8,12" />
+		</lootgroup>
+
+		<!-- NPC weapon loot groups, scaled. The groups with a single item exist to scale the item quality. -->
+		<lootgroup name="groupNPCClub" loot_quality_template="QLTemplateT0">
+			<item name="meleeWpnClubT0WoodenClub" />
+		</lootgroup>
+		<lootgroup name="groupNPCKnife" loot_quality_template="QLTemplateT1">
+			<item name="meleeWpnBladeT1HuntingKnife" />
+		</lootgroup>
+		<lootgroup name="groupNPCBat" loot_quality_template="QLTemplateT1">
+			<item name="meleeWpnClubT1BaseballBat" />
+		</lootgroup>
+		<lootgroup name="groupNPCAxe" loot_quality_template="QLTemplateT1">
+			<item name="meleeToolAxeT1IronFireaxe" count="1" />
+		</lootgroup>
+		<lootgroup name="groupNPCStoneSpear" loot_quality_template="QLTemplateT0">
+			<item name="meleeWpnSpearT0StoneSpear" count="1" />
+		</lootgroup>
+		<lootgroup name="groupNPCIronSpear" loot_quality_template="QLTemplateT1">
+			<item name="meleeWpnSpearT1IronSpear" count="1" />
+		</lootgroup>
+		<lootgroup name="groupNPCSteelSpear" loot_quality_template="QLTemplateT3">
+			<item name="meleeWpnSpearT3SteelSpear" count="1" />
+		</lootgroup>
+		<lootgroup name="groupNPCSpear">
+			<item group="groupNPCStoneSpear" loot_prob_template="ProbT0" />
+			<item group="groupNPCIronSpear" loot_prob_template="ProbT1Cap" />
+			<item group="groupNPCSteelSpear" loot_prob_template="ProbT2Cap" />
+			<item name="meleeWpnSpearT3SteelSpearParts" count="1,4" loot_prob_template="ProbT2" />
+		</lootgroup>
+		<lootgroup name="groupNPCMachete" loot_quality_template="QLTemplateT2">
+			<item name="meleeWpnBladeT3Machete" loot_prob_template="medHigh" />
+			<item name="meleeWpnBladeT3MacheteParts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCPipePistol" loot_quality_template="QLTemplateT0">
+			<item name="gunHandgunT0PipePistol" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo9mmBullet" loot_prob_template="med" />
+		</lootgroup>
+		<lootgroup name="groupNPCPistol" loot_quality_template="QLTemplateT1">
+			<item name="gunHandgunT1Pistol" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo9mmBullet" loot_prob_template="med" />
+			<item name="gunHandgunT1PistolParts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCDPistol" loot_quality_template="QLTemplateT2">
+			<item name="gunHandgunT3DesertVulture" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo44MagnumBullet" loot_prob_template="med" />
+			<item name="gunHandgunT1PistolParts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCSMG" loot_quality_template="QLTemplateT2">
+			<item name="gunHandgunT3SMG5" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo9mmBullet" loot_prob_template="med" />
+			<item name="gunHandgunT1PistolParts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCM60" loot_quality_template="QLTemplateT2">
+			<item name="gunMGT3M60" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo762mmBullet" loot_prob_template="med" />
+			<item name="gunMGT1AK47Parts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCAK47" loot_quality_template="QLTemplateT1">
+			<item name="gunMGT1AK47" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo762mmBullet" loot_prob_template="med" />
+			<item name="gunMGT1AK47Parts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCPipeMG" loot_quality_template="QLTemplateT0">
+			<item name="gunMGT0PipeMachineGun" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo9mmBullet" loot_prob_template="med" />
+		</lootgroup>
+		<lootgroup name="groupNPCTRifle" loot_quality_template="QLTemplateT1">
+			<item name="gunMGT2TacticalAR" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo762mmBullet" loot_prob_template="med" />
+			<item name="gunMGT1AK47Parts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCPipeRifle" loot_quality_template="QLTemplateT0">
+			<item name="gunRifleT0PipeRifle" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo762mmBullet" loot_prob_template="med" />
+		</lootgroup>
+		<lootgroup name="groupNPCHRifle" loot_quality_template="QLTemplateT0">
+			<item name="gunRifleT1HuntingRifle" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo762mmBullet" loot_prob_template="med" />
+			<item name="gunRifleT1HuntingRifleParts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCSRifle" loot_quality_template="QLTemplateT2">
+			<item name="gunRifleT3SniperRifle" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmo762mmBullet" loot_prob_template="med" />
+			<item name="gunRifleT1HuntingRifleParts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCPipeShotgun" loot_quality_template="QLTemplateT0">
+			<item name="gunShotgunT0PipeShotgun" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmoShotgun" loot_prob_template="med" />
+		</lootgroup>
+		<lootgroup name="groupNPCPShotgun" loot_quality_template="QLTemplateT1">
+			<item name="gunShotgunT2PumpShotgun" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmoShotgun" loot_prob_template="med" />
+			<item name="gunShotgunT1DoubleBarrelParts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCAShotgun" loot_quality_template="QLTemplateT2">
+			<item name="gunShotgunT3AutoShotgun" loot_prob_template="medHigh" />
+			<item group="groupNPCAmmoShotgun" loot_prob_template="med" />
+			<item name="gunShotgunT1DoubleBarrelParts" count="1,4" loot_prob_template="medLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCPrimitiveBow" loot_quality_template="QLTemplateT0">
+			<item name="gunBowT0PrimitiveBow" />
+		</lootgroup>
+		<lootgroup name="groupNPCWoodenBow" loot_quality_template="QLTemplateT1">
+			<item name="gunBowT1WoodenBow" />
+		</lootgroup>
+		<lootgroup name="groupNPCCompoundBow" loot_quality_template="QLTemplateT3">
+			<item name="gunBowT3CompoundBow" />
+		</lootgroup>
+		<lootgroup name="groupNPCLBow">
+			<item group="groupNPCPrimitiveBow" loot_prob_template="ProbT0" />
+			<item group="groupNPCWoodenBow" loot_prob_template="ProbT1Cap" />
+			<item group="groupNPCCompoundBow" loot_prob_template="ProbT2Cap" />
+			<item group="groupNPCAmmoArrow" loot_prob_template="low" />
+			<item name="gunBowT1WoodenBowParts" count="1,4" loot_prob_template="veryLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCIronCrossbow" loot_quality_template="QLTemplateT1">
+			<item name="gunBowT1IronCrossbow" />
+		</lootgroup>
+		<lootgroup name="groupNPCCompoundCrossbow" loot_quality_template="QLTemplateT3">
+			<item name="gunBowT3CompoundCrossbow" />
+		</lootgroup>
+		<lootgroup name="groupNPCXBow">
+			<item group="groupNPCIronCrossbow" loot_prob_template="ProbT0" />
+			<item group="groupNPCCompoundCrossbow" loot_prob_template="ProbT2EarlyCap" />
+			<item group="groupNPCAmmoCrossbowBolt" loot_prob_template="low" />
+			<item name="gunBowT1WoodenBowParts" count="1,4" loot_prob_template="veryLow" />
+		</lootgroup>
+		<lootgroup name="groupNPCRocketL" loot_quality_template="QLTemplateT3">
+			<item name="gunExplosivesT3RocketLauncher" loot_prob_template="medHigh" />
+			<item group="groupAmmoRocket" loot_prob_template="med" />
+			<item name="gunExplosivesT3RocketLauncherParts" count="1,4" loot_prob_template="low" />
+		</lootgroup>
+
+		<!--
+            These are the groups that are actually used by the loot containers.
+            They have a count of "all" to guarantee one item from the weapon/ammo group,
+            plus a chance of some backpack items.
+        -->
+		<lootgroup name="groupCntNPCClub" count="all">
+			<item group="groupNPCClub" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCKnife" count="all">
+			<item group="groupNPCKnife" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCBat" count="all">
+			<item group="groupNPCBat" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCAxe" count="all">
+			<item group="groupNPCAxe" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCSpear" count="all">
+			<item group="groupNPCSpear" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCMachete" count="all">
+			<item group="groupNPCMachete" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCPipePistol" count="all">
+			<item group="groupNPCPipePistol" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCPistol" count="all">
+			<item group="groupNPCPistol" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCDPistol" count="all">
+			<item group="groupNPCDPistol" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCSMG" count="all">
+			<item group="groupNPCSMG" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCM60" count="all">
+			<item group="groupNPCM60" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCAK47" count="all">
+			<item group="groupNPCAK47" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCPipeMG" count="all">
+			<item group="groupNPCPipeMG" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCTRifle" count="all">
+			<item group="groupNPCTRifle" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCPipeRifle" count="all">
+			<item group="groupNPCPipeRifle" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCHRifle" count="all">
+			<item group="groupNPCHRifle" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCSRifle" count="all">
+			<item group="groupNPCSRifle" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCPipeShotgun" count="all">
+			<item group="groupNPCPipeShotgun" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCPShotgun" count="all">
+			<item group="groupNPCPShotgun" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCAShotgun" count="all">
+			<item group="groupNPCAShotgun" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCLBow" count="all">
+			<item group="groupNPCLBow" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCXBow" count="all">
+			<item group="groupNPCXBow" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<lootgroup name="groupCntNPCRocketL" count="all">
+			<item group="groupNPCRocketL" count="1" />
+			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
+		</lootgroup>
+		<!-- For Mechs that use "hidden pistols" (built-in weapons) -->
+		<lootgroup name="groupCntNPCPistolHidden" count="all">
+			<item group="groupNPCAmmo9mmBullet" />
+			<item name="gunHandgunT1PistolParts" count="1,4" loot_prob_template="medLow" force_prob="true" />
+			<item group="groupNPCMechBackpacks" />
+		</lootgroup>
+	</insertBefore>
+
+	<!--
+        Custom NPC loot containers.
+    -->
+	<append xpath="/lootcontainers">
+		<lootcontainer name="cntNPCEmptyHand" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupNPCBackpacks" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCClub" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCClub" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCKnife" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCKnife" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCBat" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCBat" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCAxe" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCAxe" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCSpear" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCSpear" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCMachete" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCMachete" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCPipePistol" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCPipePistol" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCPistol" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCPistol" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCDPistol" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCDPistol" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCSMG" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="QLTemplateT0">
+			<item group="groupCntNPCSMG" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCM60" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCM60" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCAK47" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCAK47" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCPipeMG" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCPipeMG" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCTRifle" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCTRifle" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCPipeRifle" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCPipeRifle" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCHRifle" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCHRifle" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCSRifle" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCSRifle" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCPipeShotgun" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCPipeShotgun" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCPShotgun" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCPShotgun" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCAShotgun" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCAShotgun" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCLBow" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCLBow" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCXBow" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCXBow" />
+		</lootcontainer>
+		<lootcontainer name="cntNPCRocketL" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCRocketL" />
+		</lootcontainer>
+		<!-- For Mechs that use "hidden pistols" (built-in weapons) -->
+		<lootcontainer name="cntNPCPistolHidden" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupCntNPCPistolHidden" />
+		</lootcontainer>
+		<!-- For Mechs that don't use "hidden pistols" -->
+		<lootcontainer name="cntNPCMech" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
+			<item group="groupNPCMechBackpacks" />
+		</lootcontainer>
+	</append>
 
 </configs>

--- a/0-XNPCCore/Config/loot.xml
+++ b/0-XNPCCore/Config/loot.xml
@@ -5,8 +5,8 @@
 	   </append> -->
 	
 	<!--
-        NPC lootgroups - mainly weapon groups that can spawn weapons, parts, or ammo.
-    -->
+		NPC lootgroups - mainly weapon groups that can spawn weapons, parts, or ammo.
+	-->
 	<insertBefore xpath="/lootcontainers/lootcontainer[1]">
 		<!-- NPC common backpack items loot groups - tiered medical, food, drink -->
 		<lootgroup name="groupNPCMedical" count="1">
@@ -30,12 +30,12 @@
 			<item group="groupNPCDrinks" loot_prob_template="medLow" />
 		</lootgroup>
 		<!--
-            NPC Core Mechs can be harvested for resources, so don't include these items:
-            * resourceMechanicalParts
-            * resourceScrapIron
-            * resourceElectricParts
-            * resourceScrapPolymers
-        -->
+			NPC Core Mechs can be harvested for resources, so don't include these items:
+			* resourceMechanicalParts
+			* resourceScrapIron
+			* resourceElectricParts
+			* resourceScrapPolymers
+		-->
 		<lootgroup name="groupNPCMechBackpacks" count="1,3">
 			<item name="gunBotRoboticsParts" count="1,2" loot_prob_template="high" />
 			<item name="resourceAcid" count="1" loot_prob_template="veryLow" />
@@ -243,10 +243,10 @@
 		</lootgroup>
 
 		<!--
-            These are the groups that are actually used by the loot containers.
-            They have a count of "all" to guarantee one item from the weapon/ammo group,
-            plus a chance of some backpack items.
-        -->
+			These are the groups that are actually used by the loot containers.
+			They have a count of "all" to guarantee one item from the weapon/ammo group,
+			plus a chance of some backpack items.
+		-->
 		<lootgroup name="groupCntNPCClub" count="all">
 			<item group="groupNPCClub" count="1" />
 			<item group="groupNPCBackpacks" loot_prob_template="medLow" force_prob="true" />
@@ -348,8 +348,8 @@
 	</insertBefore>
 
 	<!--
-        Custom NPC loot containers.
-    -->
+		Custom NPC loot containers.
+	-->
 	<append xpath="/lootcontainers">
 		<lootcontainer name="cntNPCEmptyHand" count="1" size="6,3" destroy_on_close="false" sound_open="UseActions/open_backpack" sound_close="UseActions/close_backpack" loot_quality_template="qualBaseTemplate">
 			<item group="groupNPCBackpacks" />

--- a/0-XNPCCore/ModInfo.xml
+++ b/0-XNPCCore/ModInfo.xml
@@ -5,5 +5,5 @@
   <Description value="NPCCore Mod" />
   <DisplayName value="0-XNPCCore" />
   <Website value="" />
-  <Version value="21.1.0.6" />
+  <Version value="21.1.0.7" />
 </xml>


### PR DESCRIPTION
* `loot.xml` now has custom loot groups for weapons, ammo, and general items like food or medical, and loot containers that use them.
* `entityclasses.xml` now has custom loot drop entity classes for the weapon-specific loot containers.
* Existing NPC Core `EntityLootContainerNPC` class (which the other loot drop entity classes extend) now uses backpack model rather than zombie pack.
* NPC templates in `entityclasses.xml` updated to drop the appropriate loot drop entity class. Harley no longer overrides the templates.
* `Localization.txt` updated to translate the new loot drop entity classes - this looks worse than it is, I needed the extra CSV headers for the new translations, so I had to add the extra commas in the existing translations. The existing translations aren't actually changed.
* The patch version is bumped up in `ModInfo.xml`.