### PR TITLE
Re-ordered UAI actions so highest weight is first

### DIFF
--- a/0-XNPCCore/Config/utilityai.xml
+++ b/0-XNPCCore/Config/utilityai.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <config>
 	<remove xpath="/utility_ai/ai_packages"/>
 	<!-- Remove TFP broken UAI xml  -->
@@ -8,69 +8,76 @@
 		<!-- Note:  Place considerations that are most likely to fail before ones likely to be true, speeds up the AI calculations  -->
 		<!-- Note:  Animal NPCs can use human UAI packages, but not extensively tested and probably should have their own packages  -->
 		<!-- Dont use multiple versions of the same type of packages, like dont add the Human basic and the Human Timid basic on one character  -->
-		
+
 		<!-- Target filters (IsEnemy, IsSelf, IsPlayer, IsLeader, IsAlly )can be used on packages or on tasks.  These provide reduced context for considerations, improving efficency  -->
-		
+
 		<!-- NPCBasic is the default movement package for NPCs.  If all else fails, character should wander, otherwise follow or flee if wounded  -->
 		<!-- <consideration class="TargetDistance" min="20.0" max="40.0" curve="threshold" /> True if target range is between 20.0 and 40.0 blocks -->
 		<!-- <consideration class="TargetDistance" flip_x="true" min="2.0" max="4.0" curve="threshold" /> True if target range is between 2.0 and 4.0 blocks (if range is small, near 0, need to flip X-->
 		<!-- <consideration class="TargetDistance" flip_y="true" min="2.0" max="4.0" curve="threshold" /> True if target range is NOT between 2.0 and 4.0 blocks -->
-		
+
 		<!-- <ai_packages max_entities="30" action_delay="0.2" > -->
-		
+
 		<ai_packages max_entities="30" action_delay="0.2" >
-		
+
 	<!-- Default UAI Packages:  Naming Convention is (NPCMod)(Type[Core,NPC,Hostile,Animal,Mech])(ActionType[Melee,Ranged,ShortRanged,etc.])(Option[Basic,Advanced,NoChat]) If you add new packages, avoid using the prefix NPCCore so to avoid collisions due to duplicates  -->
-	
+
 		<!-- Required Core Packages: All NPCs need 1 of the following 4 Core packages that handles nonAttack tasks like Idling and wandering   -->
-		
+
 			<ai_package name="NPCModCore" >  <!-- Standard default package for Hirable characters  -->
-				<action name="DefaultAction" weight=".5" entity_filter="IsSelf">
-					<task class="IdleSDX, SCore" />
-				</action> 
-				<action name="Wander" weight="1" entity_filter="IsSelf">
-					<task class="WanderSDX, SCore"/>
-                    <consideration class="NotHasOrder, SCore" order="Stay"/>
-			<!--		<task class="IdleSDX, SCore" OnStartAddBuffs="RandomWanderIdle" OnStopRemoveBuffs="RandomWanderIdle" timeout="50" /> -->
-					<consideration class="EnemyNotNear, SCore" distance="30" />
-				</action>
-			<!--	<action name="OnReload" weight="3" entity_filter="IsSelf" >
-                    <task class="IdleSDX, SCore"  /> 
-                    <consideration class="SelfHasBuff, SCore" buffs="buffReload2,buffReloadDelay,buffReload3"/> 
-                </action>  -->
-				<action name="Chat" weight="2" entity_filter="IsPlayer">
-					<task class="IdleSDX, SCore" OnStartAddBuffs="RandomIdle" OnStopRemoveBuffs="RandomIdle" /> 
-					<!-- Remove this buff for "In your Face" Idle anim  -->
-					<consideration class="EnemyNotNear, SCore" distance="10" />
-					<consideration class="TargetDistance" flip_x="true" min="1" max="2.5" curve="threshold" />
-				</action> 	
-			<!--	<action name="ExitChat" weight="2" entity_filter="IsPlayer">
-                    <task class="IdleSDX, SCore" OnStartRemoveBuffs="RandomIdle" /> 
-                        <consideration class="EnemyNear, SCore" distance="30" />
-                        <consideration class="TargetDistance" flip_x="true" min="1" max="3.5" curve="threshold" />
-				</action> 	-->
-				
-                <action name="Stay" weight="2" entity_filter="IsSelf">
-                    <task class="Guard, SCore"  /> 
-                    <consideration class="EnemyNotNear, SCore" />
-                    <consideration class="HasOrder, SCore" order="Stay"/>
-                </action>
-				<action name="Guard" weight="2" entity_filter="IsSelf">
-					<task class="Guard, SCore" />
-					<consideration class="HasOrder, SCore" order="Guard" />
-				</action>
 				<action name="Flee" weight="6" entity_filter="IsEnemy">
 					<task class="FleeFromTarget" max_distance="30"/>
 					<consideration class="SelfHasCVar, SCore" cvar="$Timid" value="1"/>
 					<consideration class="TargetDistance" min="0" max="15" curve="threshold"/>
 					<consideration class="SelfVisible"/>
-				</action>	
-			</ai_package>
-				
-			<ai_package name="NPCModCoreNoChat" ><!-- Standard package for non-Hirable characters  -->
+				</action>
+			<!--	<action name="OnReload" weight="3" entity_filter="IsSelf" >
+					<task class="IdleSDX, SCore"  /> 
+					<consideration class="SelfHasBuff, SCore" buffs="buffReload2,buffReloadDelay,buffReload3"/> 
+				</action>  -->
+				<action name="Chat" weight="2" entity_filter="IsPlayer">
+					<task class="IdleSDX, SCore" OnStartAddBuffs="RandomIdle" OnStopRemoveBuffs="RandomIdle" /> 
+					<!-- Remove this buff for "In your Face" Idle anim  -->
+					<consideration class="EnemyNotNear, SCore" distance="10" />
+					<consideration class="TargetDistance" flip_x="true" min="1" max="2.5" curve="threshold" />
+				</action>
+			<!--	<action name="ExitChat" weight="2" entity_filter="IsPlayer">
+					<task class="IdleSDX, SCore" OnStartRemoveBuffs="RandomIdle" /> 
+						<consideration class="EnemyNear, SCore" distance="30" />
+						<consideration class="TargetDistance" flip_x="true" min="1" max="3.5" curve="threshold" />
+				</action> 	-->
+
+				<action name="Stay" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore"  /> 
+					<consideration class="EnemyNotNear, SCore" />
+					<consideration class="HasOrder, SCore" order="Stay"/>
+				</action>
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
+				</action>
+				<action name="Wander" weight="1" entity_filter="IsSelf">
+					<task class="WanderSDX, SCore"/>
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
+			<!--		<task class="IdleSDX, SCore" OnStartAddBuffs="RandomWanderIdle" OnStopRemoveBuffs="RandomWanderIdle" timeout="50" /> -->
+					<consideration class="EnemyNotNear, SCore" distance="30" />
+				</action>
 				<action name="DefaultAction" weight=".5" entity_filter="IsSelf">
 					<task class="IdleSDX, SCore" />
 				</action> 
+			</ai_package>
+
+			<ai_package name="NPCModCoreNoChat" ><!-- Standard package for non-Hirable characters  -->
+				<action name="Flee" weight="6" entity_filter="IsEnemy">
+					<task class="FleeFromTarget" max_distance="30"/>
+					<consideration class="SelfHasCVar, SCore" cvar="$Timid" value="1"/>
+					<consideration class="TargetDistance" min="0" max="15" curve="threshold"/>
+					<consideration class="SelfVisible"/>
+				</action>
+				<action name="Guard" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore" />
+					<consideration class="HasOrder, SCore" order="Guard" />
+				</action>
 				<action name="WanderInside" weight="1" entity_filter="IsSelf" >
 					<task class="WanderSDX, SCore"/>
 					<consideration class="IsInside, SCore" />
@@ -82,40 +89,33 @@
 					<task class="WanderSDX, SCore"/>
 					<consideration class="IsNotInside, SCore" />
 					<consideration class="NotHasOrder, SCore" order="Stay"/>
-					<consideration class="EnemyNotNear, SCore" distance="30" /> 
+					<consideration class="EnemyNotNear, SCore" distance="30" />
 				<!--	<task class="IdleSDX, SCore" OnStartAddBuffs="RandomWanderIdle" OnStopRemoveBuffs="RandomWanderIdle" timeout="50" /> -->
 				</action>
 				<action name="NoChatIdle" weight="1" entity_filter="IsPlayer">
 					<task class="IdleSDX, SCore" />
 					<consideration class="HasOrder, SCore" order="Stay"/>
-				</action> 
-				<action name="Guard" weight="2" entity_filter="IsSelf">
-					<task class="Guard, SCore" />
-					<consideration class="HasOrder, SCore" order="Guard" />
 				</action>
-				<action name="Flee" weight="6" entity_filter="IsEnemy">
-					<task class="FleeFromTarget" max_distance="30"/>
-					<consideration class="SelfHasCVar, SCore" cvar="$Timid" value="1"/>
-					<consideration class="TargetDistance" min="0" max="15" curve="threshold"/>
-					<consideration class="SelfVisible"/>
+				<action name="DefaultAction" weight=".5" entity_filter="IsSelf">
+					<task class="IdleSDX, SCore" />
 				</action>
 			</ai_package>
-			
+
 			<ai_package name="NPCModNPCHired" entity_filter="IsLeader" >  
-                <action name="TooCloseInside" weight="3" >
-                    <task class="BackupFromTargetSDX, SCore" max_distance="2.5"/>
-                    <consideration class="EnemyNotNear, SCore" distance="20" />
-                    <consideration class="IsInside, SCore" />
-                    <consideration class="TargetDistance"  flip_x="true" min="0" max="2.5"  />
-                    <consideration class="NotHasOrder, SCore" order="Stay"/>
-                </action> 
-                <action name="TooCloseOutside" weight="3">
-                    <task class="BackupFromTargetSDX, SCore" max_distance="2.5"/>
-                    <consideration class="EnemyNotNear, SCore" distance="20" />
-                    <consideration class="IsNotInside, SCore" />
-                    <consideration class="TargetDistance" flip_x="true"  min="0" max="1"  />
-                    <consideration class="NotHasOrder, SCore" order="Stay"/>
-                </action> 
+				<action name="TooCloseInside" weight="3" >
+					<task class="BackupFromTargetSDX, SCore" max_distance="2.5"/>
+					<consideration class="EnemyNotNear, SCore" distance="20" />
+					<consideration class="IsInside, SCore" />
+					<consideration class="TargetDistance"  flip_x="true" min="0" max="2.5"  />
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
+				</action> 
+				<action name="TooCloseOutside" weight="3">
+					<task class="BackupFromTargetSDX, SCore" max_distance="2.5"/>
+					<consideration class="EnemyNotNear, SCore" distance="20" />
+					<consideration class="IsNotInside, SCore" />
+					<consideration class="TargetDistance" flip_x="true"  min="0" max="1"  />
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
+				</action> 
 				<action name="LeaderFollow" weight="2" >
 					<task class="FollowSDX, SCore" OnStartAddBuffs="NPCpegasus" OnStopRemoveBuffs="NPCpegasus"/>
 					<consideration class="HasOrder, SCore" order="Follow"/>
@@ -127,15 +127,23 @@
 					<consideration class="HasOrder, SCore" order="Follow"/>
 					<consideration class="TargetDistance"  flip_x="true" min="2.5" max="20" curve="threshold"/>
 					 <consideration class="EnemyNotNear, SCore" distance="20" />
-				</action>	
+				</action>
 			</ai_package> 
-			
-			
-				
+
+
+
 	<!-- BASIC (Friendly/Neutral) NPC AI PACKAGES, without the hiring controls, which reduces networking load. -->
-	
+
 			<ai_package name="NPCModNPCMeleeBasic" entity_filter="IsEnemy"> 
 				<!-- DEFAULT ACTIONS -->
+				<action name="MeleeAttackEntityBasic" weight="5">
+					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
+					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="InWeaponRange, SCore" action_index="0" /> 
+					<consideration class="CanSeeTarget, SCore"/> 
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing,buffHitStun"/>
+				</action>
 				<action name="MoveToEnemyRunMelee" weight="4">
 					<task class="MoveToAttackTargetSDX, SCore" run="true" />
 					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
@@ -145,17 +153,25 @@
 					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing,buffHitStun"/>
 					<consideration class="NotHasOrder, SCore" order="Stay"/>
 				</action>
-				<action name="MeleeAttackEntityBasic" weight="5">
+			</ai_package>
+
+			<ai_package name="NPCModNPCRangedBasic" entity_filter="IsEnemy" >
+				<action name="RangedMeleeAttack" weight="6">
 					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
-					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
 					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="InWeaponRange, SCore" action_index="0" /> 
-					<consideration class="CanSeeTarget, SCore"/> 
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing,buffHitStun"/>
+					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>
 				</action>
-			</ai_package>	
-			
-			<ai_package name="NPCModNPCRangedBasic" entity_filter="IsEnemy" > 
+				<action name="RangedAttack" weight="5">
+					<task class="AttackTargetEntitySDX, SCore" action_index="1" />
+					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
+					<consideration class="CanSeeTarget, SCore" />
+					<consideration class="InWeaponRange, SCore" action_index="1" />
+					<consideration class="SelfNotHasBuff, SCore" buffs="RandomIdle,buffBurstDelay,IsHealing,buffReload2,buffReloadDelay,buffReload3,buffHitStun" />
+				</action>
 				<action name="MoveToEnemyShortRanged" weight="4">
 					<task class="MoveToAttackTargetSDX, SCore" run="false" action_index="1" />
 					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="1"/>
@@ -179,22 +195,6 @@
 					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
 					<consideration class="CanSeeTarget, SCore" />
 					<consideration class="NotHasOrder, SCore" order="Stay" />
-				</action>
-				<action name="RangedMeleeAttack" weight="6">
-					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
-					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
-					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>	
-				</action>
-				<action name="RangedAttack" weight="5">
-					<task class="AttackTargetEntitySDX, SCore" action_index="1" />
-					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
-					<consideration class="CanSeeTarget, SCore" />
-					<consideration class="InWeaponRange, SCore" action_index="1" />
-					<consideration class="SelfNotHasBuff, SCore" buffs="RandomIdle,buffBurstDelay,IsHealing,buffReload2,buffReloadDelay,buffReload3,buffHitStun" />
 				</action>
 				<action name="BackupShortRanged" weight="3">
 					<task class="BackupFromTargetSDX, SCore" run="false" max_distance="5"/> 
@@ -220,13 +220,40 @@
 					<consideration class="CanSeeTarget, SCore"/>
 					<consideration class="NotHasOrder, SCore" order="Stay"/>
 				</action>
-			</ai_package>	
-			
+			</ai_package>
+
 
 
 		<!-- AI Packages for Advanced NPC Templates, Hireable character with Leader Controls available -->
-		
-			<ai_package name="NPCModNPCMeleeAdvanced" entity_filter="IsEnemy"> 
+
+			<ai_package name="NPCModNPCMeleeAdvanced" entity_filter="IsEnemy">
+				<!-- FULL CONTROL ACTIONS - NO PLAYER COMMANDS -->
+				<action name="LeaderFollowControl" weight="10" >
+					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
+					<task class="FollowSDX, SCore" OnStartAddBuffs="NPCpegasus" OnStopRemoveBuffs="NPCpegasus"/>
+					<consideration class="HasOrder, SCore" order="Follow"/>
+				</action>
+				<!-- DEFAULT ACTIONS -->
+				<action name="MeleeAttackEntity" weight="5">
+					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
+					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="InWeaponRange, SCore" action_index="0" /> 
+					<consideration class="CanSeeTarget, SCore"/> 
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing,buffHitStun"/>
+				</action>
+				<!-- CONTROL ACTIONS - PLAYER IS BEING ATTACKED OR GAVE ATTACK COMMAND -->
+				<action name="MeleeAttackEntityControlAttacked" weight="5">
+					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
+					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="InWeaponRange, SCore" action_index="0" /> 
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking,IsHealing,buffHitStun"/>
+				</action> 
 				<!-- DEFAULT ACTIONS -->
 				<action name="MoveToEnemyRunMelee" weight="4">
 					<task class="MoveToAttackTargetSDX, SCore" run="true" />
@@ -234,23 +261,8 @@
 					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
 					<consideration class="NotInWeaponRange, SCore" action_index="0" /> 
 					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,buffHitStun"/>	
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,buffHitStun"/>
 					<consideration class="NotHasOrder, SCore" order="Stay"/>
-				</action>
-				<action name="MeleeAttackEntity" weight="5">
-					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
-					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="InWeaponRange, SCore" action_index="0" /> 
-					<consideration class="CanSeeTarget, SCore"/> 
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing,buffHitStun"/>	
-				</action>
-				<!-- FULL CONTROL ACTIONS - NO PLAYER COMMANDS -->
-				<action name="LeaderFollowControl" weight="10" >
-					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
-					<task class="FollowSDX, SCore" OnStartAddBuffs="NPCpegasus" OnStopRemoveBuffs="NPCpegasus"/>
-					<consideration class="HasOrder, SCore" order="Follow"/>
 				</action>
 				<!-- CONTROL ACTIONS - PLAYER IS BEING ATTACKED OR GAVE ATTACK COMMAND -->
 				<action name="MoveToEnemyRunMeleeControlAttacked" weight="4">
@@ -261,25 +273,68 @@
 					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
 					<consideration class="NotInWeaponRange, SCore" action_index="0" /> 
 					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking,buffHitStun"/>	
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking,buffHitStun"/>
 					<consideration class="NotHasOrder, SCore" order="Stay"/>
 				</action>
-				<action name="MeleeAttackEntityControlAttacked" weight="5">
-					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
-					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="InWeaponRange, SCore" action_index="0" /> 
-					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking,IsHealing,buffHitStun"/>	
-				</action> 
-			</ai_package>	
-			
+			</ai_package>
 
-			<ai_package name="NPCModNPCRangedAdvanced" entity_filter="IsEnemy" > 
+
+			<ai_package name="NPCModNPCRangedAdvanced" entity_filter="IsEnemy" >
+				<!-- CONTROL ACTIONS - STOP ATTACKING AND FOLLOW -->
+				<action name="LeaderFollowControl" weight="10" >
+					<task class="FollowSDX, SCore" OnStartAddBuffs="NPCpegasus" OnStopRemoveBuffs="NPCpegasus"/>
+					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
+					<consideration class="HasOrder, SCore" order="Follow"/>
+				</action>
+
 				<!-- DEFAULT ACTIONS -->
-			
+				<action name="RangedMeleeAttack" weight="6">
+					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
+					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>
+				</action>
+				<!-- CONTROL ACTIONS - PLAYER IS BEING ATTACKED OR GAVE ATTACK COMMAND -->
+				<action name="RangedMeleeAttackControlAttacked" weight="6">
+					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
+					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
+					<consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>
+				</action>
+
+				<!-- DEFAULT ACTIONS -->
+				<action name="RangedAttack" weight="5">
+					<task class="AttackTargetEntitySDX, SCore" action_index="1" />
+					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
+					<consideration class="CanSeeTarget, SCore" />
+					<consideration class="InWeaponRange, SCore" action_index="1" />
+					<consideration class="SelfNotHasBuff, SCore" buffs="RandomIdle,buffBurstDelay,IsHealing,buffReload2,buffReloadDelay,buffReload3,buffHitStun" />
+				</action>
+				<!-- CONTROL ACTIONS - PLAYER IS BEING ATTACKED OR GAVE ATTACK COMMAND -->
+				<action name="RangedAttackControlAttacked" weight="5">
+					<task class="AttackTargetEntitySDX, SCore" action_index="1" />
+					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
+					<consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
+					<consideration class="CanSeeTarget, SCore" />
+					<consideration class="InWeaponRange, SCore" action_index="1" />
+					<consideration class="SelfNotHasBuff, SCore" buffs="RandomIdle,buffBurstDelay,IsHealing,buffReload2,buffReloadDelay,buffReload3,buffHitStun" />
+				</action>
+
+				<!-- DEFAULT ACTIONS -->
 				<action name="MoveToEnemyShortRanged" weight="4">
 					<task class="MoveToAttackTargetSDX, SCore" run="false" action_index="1" />
 					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="1"/>
@@ -306,63 +361,8 @@
 					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
 					<consideration class="CanSeeTarget, SCore" />
 					<consideration class="NotHasOrder, SCore" order="Stay" /> 
-				</action> 
-				<action name="RangedMeleeAttack" weight="6">
-					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
-					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
-					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>	
 				</action>
-				<action name="RangedAttack" weight="5">
-					<task class="AttackTargetEntitySDX, SCore" action_index="1" />
-					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
-					<consideration class="CanSeeTarget, SCore" />
-					<consideration class="InWeaponRange, SCore" action_index="1" />
-					<consideration class="SelfNotHasBuff, SCore" buffs="RandomIdle,buffBurstDelay,IsHealing,buffReload2,buffReloadDelay,buffReload3,buffHitStun" />
-				</action>
-				<action name="BackupShortRanged" weight="3">
-					<task class="BackupFromTargetSDX, SCore" run="false" max_distance="5"/> 
-					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="1"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="TargetDistance"  flip_x="true" min="1" max="5"  curve="threshold" /> 
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="NotHasOrder, SCore" order="Stay"/>
-				</action>
-				<action name="BackupMediumRanged" weight="3">
-					<task class="BackupFromTargetSDX, SCore" run="false" max_distance="10"/>
-					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="2"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="TargetDistance"  flip_x="true" min="1" max="10"  curve="threshold" />
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="NotHasOrder, SCore" order="Stay"/>
-				</action>
-				<action name="BackupLongRanged" weight="3">
-					<task class="BackupFromTargetSDX, SCore" run="false" max_distance="10"/>
-					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="3"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="TargetDistance"  flip_x="true" min="1" max="15"  curve="threshold" />
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="NotHasOrder, SCore" order="Stay"/>
-				</action>
-	
-				<!-- CONTROL ACTIONS - STOP ATTACKING AND FOLLOW -->
-				<action name="LeaderFollowControl" weight="10" >
-					<task class="FollowSDX, SCore" OnStartAddBuffs="NPCpegasus" OnStopRemoveBuffs="NPCpegasus"/>
-					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
-					<consideration class="HasOrder, SCore" order="Follow"/>
-				</action>
-				
 				<!-- CONTROL ACTIONS - PLAYER IS BEING ATTACKED OR GAVE ATTACK COMMAND -->
-				
 				<action name="MoveToEnemyShortRanged" weight="4">
 					<task class="MoveToAttackTargetSDX, SCore" run="false" action_index="1" />
 					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="1"/>
@@ -396,28 +396,36 @@
 					<consideration class="CanSeeTarget, SCore" />
 					<consideration class="NotHasOrder, SCore" order="Stay" />
 				</action>
-				<action name="RangedMeleeAttackControlAttacked" weight="6">
-					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
-					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
-					<consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
+
+				<!-- DEFAULT ACTIONS -->
+				<action name="BackupShortRanged" weight="3">
+					<task class="BackupFromTargetSDX, SCore" run="false" max_distance="5"/> 
+					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="1"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="TargetDistance"  flip_x="true" min="1" max="5"  curve="threshold" /> 
 					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
 					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>	
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
 				</action>
-				<action name="RangedAttackControlAttacked" weight="5">
-					<task class="AttackTargetEntitySDX, SCore" action_index="1" />
-					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<consideration class="SelfHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
-					<consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
-					<consideration class="CanSeeTarget, SCore" />
-					<consideration class="InWeaponRange, SCore" action_index="1" />
-					<consideration class="SelfNotHasBuff, SCore" buffs="RandomIdle,buffBurstDelay,IsHealing,buffReload2,buffReloadDelay,buffReload3,buffHitStun" />
+				<action name="BackupMediumRanged" weight="3">
+					<task class="BackupFromTargetSDX, SCore" run="false" max_distance="10"/>
+					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="2"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="TargetDistance"  flip_x="true" min="1" max="10"  curve="threshold" />
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
 				</action>
+				<action name="BackupLongRanged" weight="3">
+					<task class="BackupFromTargetSDX, SCore" run="false" max_distance="10"/>
+					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="3"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode"/>
+					<consideration class="TargetDistance"  flip_x="true" min="1" max="15"  curve="threshold" />
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
+				</action>
+				<!-- CONTROL ACTIONS - PLAYER IS BEING ATTACKED OR GAVE ATTACK COMMAND -->
 				<action name="BackupShortRanged" weight="3">
 					<task class="BackupFromTargetSDX, SCore" run="false" max_distance="5"/> 
 					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="1"/>
@@ -451,49 +459,75 @@
 					<consideration class="CanSeeTarget, SCore"/>
 					<consideration class="NotHasOrder, SCore" order="Stay"/>
 				</action>
-			</ai_package>	
-			
+			</ai_package>
+
 			<!-- BASIC HOSTILE AI PACKAGES, for bandits like Harley that will not be hired -->
-			
+
 			<ai_package name="NPCModHostileMeleeBasic" entity_filter="IsEnemy"> 
 				<!-- DEFAULT ACTIONS -->
-				<action name="MoveToEnemyRunMelee" weight="4">
-					<task class="MoveToAttackTargetSDX, SCore" run="true" />
-					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-				<!--	<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/> -->
-					<consideration class="NotInWeaponRange, SCore" action_index="0" /> 
-					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing"/>	
-					<consideration class="NotHasOrder, SCore" order="Stay"/>
-				</action>
-				 <action name="MoveToRandomTarget" weight="3" entity_filter="IsPlayer" >
-                    <task class="MoveToInvestigate, SCore" run="true" />
-					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-                 <!--   <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/> -->
-                    <consideration class="NotInWeaponRange, SCore" action_index="0" /> 
-                    <consideration class="CanNotSeeTarget, SCore"/>
-					<consideration class="CanHearTarget, SCore" />
-					<consideration class="NotPathBlockedSDX, SCore"  />
-                    <consideration class="NotHasOrder, SCore" order="Stay"/>
-                 </action>    					
 				<action name="MeleeAttackEntity" weight="5">
 					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
 					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
 				<!--	<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/> -->
 					<consideration class="InWeaponRange, SCore" action_index="0" /> 
 					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing,buffHitStun"/>	
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing,buffHitStun"/>
+				</action>
+				<action name="MoveToEnemyRunMelee" weight="4">
+					<task class="MoveToAttackTargetSDX, SCore" run="true" />
+					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+				<!--	<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/> -->
+					<consideration class="NotInWeaponRange, SCore" action_index="0" /> 
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing"/>
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
 				</action>
 				<!-- <action name="MeleeAttackBlock" weight="4">
-                    <task class="AttackTargetEntitySDX, SCore" action_index="0"/>
+					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
 					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-                    <consideration class="PathBlockedSDX, SCore"  />
-                    <consideration class="TargetType" type="Block"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing,buffHitStun"/>	
-                </action> -->
+					<consideration class="PathBlockedSDX, SCore"  />
+					<consideration class="TargetType" type="Block"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModFullControlMode,IsHealing,buffHitStun"/>
+				</action> -->
+				 <action name="MoveToRandomTarget" weight="3" entity_filter="IsPlayer" >
+					<task class="MoveToInvestigate, SCore" run="true" />
+					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+				 <!--   <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/> -->
+					<consideration class="NotInWeaponRange, SCore" action_index="0" /> 
+					<consideration class="CanNotSeeTarget, SCore"/>
+					<consideration class="CanHearTarget, SCore" />
+					<consideration class="NotPathBlockedSDX, SCore"  />
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
+				 </action>
 			</ai_package>
 
-			<ai_package name="NPCModHostileRangedBasic" entity_filter="IsEnemy" > 
+			<ai_package name="NPCModHostileRangedBasic" entity_filter="IsEnemy" >
+				<action name="RangedMeleeAttack" weight="7">
+					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
+					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<!-- <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/> -->
+					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>
+				</action>
+				<action name="RangedAttack" weight="6">
+					<task class="AttackTargetEntitySDX, SCore" action_index="1" />
+					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+					<!-- <consideration class="FailOnDistanceToLeader, SCore" max_distance="30" /> -->
+					<consideration class="CanSeeTarget, SCore" />
+					<consideration class="InWeaponRange, SCore" action_index="1" />
+					<consideration class="SelfNotHasBuff, SCore" buffs="RandomIdle,buffBurstDelay,IsHealing,buffReload2,buffReloadDelay,buffReload3,buffHitStun" />
+				</action>
+				<action name="MoveToRandomTarget" weight="5" entity_filter="IsPlayer" >
+				   <task class="MoveToInvestigate, SCore" run="true" />
+				   <consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
+				   <!-- <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/> -->
+				   <!-- <consideration class="NotInWeaponRange, SCore" action_index="0" /> -->
+				   <consideration class="CanNotSeeTarget, SCore"/> 
+				   <consideration class="CanHearTarget, SCore" /> 
+				   <!-- <consideration class="NotPathBlockedSDX, SCore"  /> -->  <!-- not sure we need this -->
+				   <consideration class="NotHasOrder, SCore" order="Stay"/>
+				</action>
 				<action name="MoveToEnemyShortRanged" weight="4">
 					<task class="MoveToAttackTargetSDX, SCore" run="false" action_index="1" />
 					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="1"/>
@@ -518,32 +552,18 @@
 					<consideration class="CanSeeTarget, SCore" />
 					<consideration class="NotHasOrder, SCore" order="Stay" />
 				</action>
-				 <action name="MoveToRandomTarget" weight="5" entity_filter="IsPlayer" >
-                    <task class="MoveToInvestigate, SCore" run="true" />
-					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-                    <!-- <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/> -->
-                    <!-- <consideration class="NotInWeaponRange, SCore" action_index="0" /> -->
-                    <consideration class="CanNotSeeTarget, SCore"/> 
-					<consideration class="CanHearTarget, SCore" /> 
-					<!-- <consideration class="NotPathBlockedSDX, SCore"  /> -->  <!-- not sure we need this -->
-                    <consideration class="NotHasOrder, SCore" order="Stay"/>
-                 </action>    					
-				<action name="RangedMeleeAttack" weight="7">
+				<!--<action name="RangedMeleeAttackBlock" weight="4">
 					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
 					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<!-- <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/> -->
-					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
-					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>	
-				</action>
-				<action name="RangedAttack" weight="6">
-					<task class="AttackTargetEntitySDX, SCore" action_index="1" />
+					<consideration class="PathBlockedSDX, SCore"  />
+					<consideration class="TargetType" type="Block"/>
+				</action> -->
+				<!--<action name="RangedAttackBlock" weight="4">
+					<task class="AttackTargetEntitySDX, SCore" action_index="1"/>
 					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-					<!-- <consideration class="FailOnDistanceToLeader, SCore" max_distance="30" /> -->
-					<consideration class="CanSeeTarget, SCore" />
-					<consideration class="InWeaponRange, SCore" action_index="1" />
-					<consideration class="SelfNotHasBuff, SCore" buffs="RandomIdle,buffBurstDelay,IsHealing,buffReload2,buffReloadDelay,buffReload3,buffHitStun" />
-				</action>
+					<consideration class="PathBlockedSDX, SCore"  />
+					<consideration class="TargetType" type="Block"/>
+				</action> -->
 				<action name="BackupShortRanged" weight="3">
 					<task class="BackupFromTargetSDX, SCore" run="false" max_distance="3"/> 
 					<consideration class="SelfHasCVar, SCore" cvar="CurrentWeaponClass" value="1"/>
@@ -568,28 +588,34 @@
 					<consideration class="CanSeeTarget, SCore"/>
 					<consideration class="NotHasOrder, SCore" order="Stay"/>
 				</action>
-				<!--<action name="RangedMeleeAttackBlock" weight="4">
-                    <task class="AttackTargetEntitySDX, SCore" action_index="0"/>
-					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-                    <consideration class="PathBlockedSDX, SCore"  />
-                    <consideration class="TargetType" type="Block"/>
-                </action> -->
-				<!--<action name="RangedAttackBlock" weight="4">
-                    <task class="AttackTargetEntitySDX, SCore" action_index="1"/>
-					<consideration class="SelfNotHasCVar, SCore" cvar="CurrentWeaponClass" value="0"/>
-                    <consideration class="PathBlockedSDX, SCore"  />
-                    <consideration class="TargetType" type="Block"/>
-                </action> -->
-				
-			</ai_package>		
-			
-			
+
+			</ai_package>
+
+
 
 <!-- Specific Utility Functions   -->
 
 
-			
-			<ai_package name="NPCModNPCMedic" entity_filter="IsAlly" > 
+
+			<ai_package name="NPCModNPCMedic" entity_filter="IsAlly" >
+				<!-- Action to move the NPC close to the ally who needs help -->
+				<action name="MoveToHeal" weight="6">
+					<task class="MoveToAttackTargetSDX, SCore" run="true" />
+					<consideration class="TargetHealthSDX, SCore" min="0.01" max="0.65"/>
+					<consideration class="TargetDistance"  min="4" max="10" curve="threshold"/>
+					<consideration class="TargetNotHasBuff, SCore" buffs="buffHealHealth,buffProcessConsumables"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing"/>
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
+				</action>
+				<!-- Action to move the NPC close to the ally who needs help, specifically for sprained limbs. -->
+				<!-- The above only moves them if their heal is low, whereas this is necessary for a broken limb, which may not trigger the health check -->
+				<action name="MoveToMend" weight="6">
+					<task class="MoveToAttackTargetSDX, SCore" run="true" />
+					<consideration class="TargetHasBuff, SCore" buffs="buffArmSprained,buffArmBroken,buffLegBroken,buffLegSprained"/>
+					<consideration class="TargetDistance"  min="4" max="10" curve="threshold"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing"/>
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
+				</action>
 				<action name="HealOther" weight="5">
 					<task class="HealSDX, SCore" run="true" OnStartAddBuffs="IsHealing" OnStopAddBuffsTarget="buffProcessConsumables"/>
 					<consideration class="TargetHealthSDX, SCore" min="0.01" max="0.65"/>
@@ -604,45 +630,27 @@
 					<consideration class="TargetDistance"   min="2" max="4" curve="threshold"/>
 					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing"/>
 					<consideration class="TargetNotHasBuff, SCore" buffs="buffHealHealth,buffProcessConsumables"/>
-				</action>			
+				</action>
 				<action name="MendArmOther" weight="5">
 					<task class="HealSDX, SCore" run="true" OnStartAddBuffs="IsHealing" OnStopAddBuffsTarget="buffArmSplinted"/>
 					<consideration class="TargetHasBuff, SCore" buffs="buffArmSprained,buffArmBroken"/>
 					<consideration class="TargetDistance"   min="2" max="4" curve="threshold" />
 					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing"/>
-					<consideration class="TargetNotHasBuff, SCore" buffs="buffHealHealth,buffProcessConsumables"/>	
-				</action>
-				<!-- Action to move the NPC close to the ally who needs help -->
-				<action name="MoveToHeal" weight="6">
-					<task class="MoveToAttackTargetSDX, SCore" run="true" />
-					<consideration class="TargetHealthSDX, SCore" min="0.01" max="0.65"/>
-					<consideration class="TargetDistance"  min="4" max="10" curve="threshold"/>
-					<consideration class="TargetNotHasBuff, SCore" buffs="buffHealHealth,buffProcessConsumables"/>		
-					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing"/>
-					<consideration class="NotHasOrder, SCore" order="Stay"/>
-				</action>
-				<!-- Action to move the NPC close to the ally who needs help, specifically for sprained limbs. -->
-				<!-- The above only moves them if their heal is low, whereas this is necessary for a broken limb, which may not trigger the health check -->
-				<action name="MoveToMend" weight="6">
-					<task class="MoveToAttackTargetSDX, SCore" run="true" />
-					<consideration class="TargetHasBuff, SCore" buffs="buffArmSprained,buffArmBroken,buffLegBroken,buffLegSprained"/>
-					<consideration class="TargetDistance"  min="4" max="10" curve="threshold"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing"/>
-					<consideration class="NotHasOrder, SCore" order="Stay"/>
+					<consideration class="TargetNotHasBuff, SCore" buffs="buffHealHealth,buffProcessConsumables"/>
 				</action>
 			</ai_package>
-			
+
 			<ai_package name="NPCModNPCLoot">
-                <action name="LootBasic" weight="2" entity_filter="IsSelf" >
-                    <task class="Loot, SCore" run="false" TargetType="Loot, SecureLoot" buff="ActivityBuff"/>
-                    <consideration class="HasOrder, SCore" order="Loot"/>
-                   <consideration class="EnemyNotNear, SCore" distance="15"/> 
-                   <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-                   <consideration class="SelfNotHasBuff, SCore" buffs="ActivityCoolDown"/>
-                   <consideration class="HasPath, SCore" TargetType="Loot, SecureLoot" />
-                </action>
-            </ai_package>
-			
+				<action name="LootBasic" weight="2" entity_filter="IsSelf" >
+					<task class="Loot, SCore" run="false" TargetType="Loot, SecureLoot" buff="ActivityBuff"/>
+					<consideration class="HasOrder, SCore" order="Loot"/>
+				   <consideration class="EnemyNotNear, SCore" distance="15"/> 
+				   <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+				   <consideration class="SelfNotHasBuff, SCore" buffs="ActivityCoolDown"/>
+				   <consideration class="HasPath, SCore" TargetType="Loot, SecureLoot" />
+				</action>
+			</ai_package>
+
 			<ai_package name="NPCModNPCCrafter"> <!--  Not hooked up yet  -->
 				<action name="Craft Basic" weight="2">
 					<task class="MoveToExplore, SCore" run="false" buff="ActivityBuff"/>
@@ -663,18 +671,18 @@
 					<task class="Farming, SCore" run="false" buff="IsGathering"/>
 					<!-- Default distance is 10 if distance is not specified.-->
 					<consideration class="IsNearFarm, SCore" distance="40" />
-				
+
 					<!-- Don't do farming if the enemies are dear by-->
 					<consideration class="EnemyNotNear, SCore" distance="15"/>
 				</action>
 			</ai_package>
 			<ai_package name="NPCModNPCShortRangedVomit" entity_filter="IsEnemy" > <!-- testing only  -->
-				<action name="MoveToEnemyShortRanged" weight="4">
-					<task class="MoveToAttackTargetSDX, SCore" run="false" action_index="1" />
-					<consideration class="TargetDistance"  min="15" max="40" curve="threshold" /> 
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
-					<consideration class="CanSeeTarget, SCore" />
-					<consideration class="NotHasOrder, SCore" order="Stay" />
+				<action name="RangedMeleeAttack" weight="6">
+					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>
 				</action>
 				<action name="VomitAttackClose" weight="5">
 					<task class="AttackTargetEntitySDX, SCore" action_index="2" />
@@ -683,88 +691,72 @@
 					<!-- <consideration class="InWeaponRange, SCore" action_index="2" /> -->
 					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun" />
 				</action>
-				<action name="RangedMeleeAttack" weight="6">
-					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
-					<consideration class="CanSeeTarget, SCore"/>
-					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing,buffHitStun"/>	
+				<action name="MoveToEnemyShortRanged" weight="4">
+					<task class="MoveToAttackTargetSDX, SCore" run="false" action_index="1" />
+					<consideration class="TargetDistance"  min="15" max="40" curve="threshold" /> 
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
+					<consideration class="CanSeeTarget, SCore" />
+					<consideration class="NotHasOrder, SCore" order="Stay" />
 				</action>
-			</ai_package>	
-	
-	
+			</ai_package>
+
+
 
 <!--  Animal Packages  -->
-		
+
 			<ai_package name="NPCModAnimalHired" entity_filter="IsLeader" >
-                <action name="TooCloseInside" weight="3">
-                    <task class="BackupFromTargetSDX, SCore" max_distance="3.5"/>
-                    <consideration class="EnemyNotNear, SCore" />
-                    <consideration class="IsInside, SCore" />
-                    <consideration class="TargetDistance" flip_x="true" min="0" max="3"  />
-                    <consideration class="NotHasOrder, SCore" order="Stay"/>
-                </action> 
-                <action name="TooCloseOutside" weight="3">
-                    <task class="BackupFromTargetSDX, SCore" max_distance="3.5"/>
-                    <consideration class="EnemyNotNear, SCore" />
-                    <consideration class="IsNotInside, SCore" />
-                    <consideration class="TargetDistance" flip_x="true" min="0" max="1"  />
-                    <consideration class="NotHasOrder, SCore" order="Stay"/>
-                </action> 
-                <action name="LeaderFollow" weight="2" >
-                    <task class="FollowSDX, SCore" OnStartAddBuffs="NPCpegasus" OnStopRemoveBuffs="NPCpegasus"/>
-                    <consideration class="HasOrder, SCore" order="Follow"/>
-                    <consideration class="EnemyNotNear, SCore"/>
-                    <consideration class="TargetDistance"  flip_x="true" min="7" max="40" curve="threshold" />
-                </action>
-                <action name="LeaderFollowSlow" weight="2" >
-                    <task class="FollowSDX, SCore"/>
-                    <consideration class="HasOrder, SCore" order="Follow"/>
-                    <consideration class="EnemyNotNear, SCore"/>
-                    <consideration class="TargetDistance"  flip_x="true" min="2" max="6" curve="threshold"/>
-                </action>
-            </ai_package>
-			
-			<ai_package name="NPCModAnimalMeleeAdvanced" entity_filter="IsEnemy"> 
-                <!-- CONTROL ACTIONS - PLAYER IS BEING ATTACKED OR IS ATTACKING A TARGET -->
-                <action name="MoveToEnemyRunMeleeControlAttacked" weight="4">
-                    <consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
-					<task class="MoveToAttackTargetSDX, SCore" run="true" />
-                    <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-                    <consideration class="NotInWeaponRange, SCore" action_index="0" /> 
-                    <consideration class="CanSeeTarget, SCore"/>
-                    <consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking"/>    
-                    <consideration class="NotHasOrder, SCore" order="Stay"/>
-                </action>
-                <action name="MeleeAttackEntityControlAttacked" weight="5">
-                    <consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
-                    <task class="AttackTargetEntitySDX, SCore" action_index="0"/>
-                    <consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
-                    <consideration class="InWeaponRange, SCore" action_index="0" /> 
-                    <consideration class="CanSeeTarget, SCore"/>
-                    <consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking"/>    
-                </action>
-            </ai_package>    
-			
-			<!--  Mech Packages  -->
-			
-			<ai_package name="NPCModMechCore" >
-				<action name="DefaultAction" weight=".5" entity_filter="IsSelf">
-					<task class="IdleSDX, SCore" />
+				<action name="TooCloseInside" weight="3">
+					<task class="BackupFromTargetSDX, SCore" max_distance="3.5"/>
+					<consideration class="EnemyNotNear, SCore" />
+					<consideration class="IsInside, SCore" />
+					<consideration class="TargetDistance" flip_x="true" min="0" max="3"  />
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
 				</action> 
-				<action name="Wander" weight="1" entity_filter="IsSelf">
-					<task class="WanderSDX, SCore"/>
+				<action name="TooCloseOutside" weight="3">
+					<task class="BackupFromTargetSDX, SCore" max_distance="3.5"/>
+					<consideration class="EnemyNotNear, SCore" />
+					<consideration class="IsNotInside, SCore" />
+					<consideration class="TargetDistance" flip_x="true" min="0" max="1"  />
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
+				</action> 
+				<action name="LeaderFollow" weight="2" >
+					<task class="FollowSDX, SCore" OnStartAddBuffs="NPCpegasus" OnStopRemoveBuffs="NPCpegasus"/>
+					<consideration class="HasOrder, SCore" order="Follow"/>
+					<consideration class="EnemyNotNear, SCore"/>
+					<consideration class="TargetDistance"  flip_x="true" min="7" max="40" curve="threshold" />
 				</action>
-				<action name="Chat" weight="2" entity_filter="IsPlayer">
-                    <task class="IdleSDX, SCore" /> 
-                        <consideration class="EnemyNotNear, SCore" distance="20" />
-                        <consideration class="TargetDistance" flip_x="true" min="1" max="3.5" curve="threshold" />
-				</action> 
-                <action name="Stay" weight="2" entity_filter="IsSelf">
-                    <task class="Guard, SCore"  /> 
-                    <consideration class="EnemyNotNear, SCore" />
-                    <consideration class="HasOrder, SCore" order="Stay"/>
-                </action> 
+				<action name="LeaderFollowSlow" weight="2" >
+					<task class="FollowSDX, SCore"/>
+					<consideration class="HasOrder, SCore" order="Follow"/>
+					<consideration class="EnemyNotNear, SCore"/>
+					<consideration class="TargetDistance"  flip_x="true" min="2" max="6" curve="threshold"/>
+				</action>
+			</ai_package>
+
+			<ai_package name="NPCModAnimalMeleeAdvanced" entity_filter="IsEnemy"> 
+				<!-- CONTROL ACTIONS - PLAYER IS BEING ATTACKED OR IS ATTACKING A TARGET -->
+				<action name="MeleeAttackEntityControlAttacked" weight="5">
+					<consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
+					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="InWeaponRange, SCore" action_index="0" /> 
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
+				</action>
+				<action name="MoveToEnemyRunMeleeControlAttacked" weight="4">
+					<consideration class="TargetHasBuff, SCore" buffs="buffNPCModAttacking"/>
+					<task class="MoveToAttackTargetSDX, SCore" run="true" />
+					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
+					<consideration class="NotInWeaponRange, SCore" action_index="0" /> 
+					<consideration class="CanSeeTarget, SCore"/>
+					<consideration class="SelfNotHasBuff, SCore" buffs="buffNPCModStopAttacking"/>
+					<consideration class="NotHasOrder, SCore" order="Stay"/>
+				</action>
+			</ai_package>
+
+			<!--  Mech Packages  -->
+
+			<ai_package name="NPCModMechCore" >
 				<action name="HealSelf" weight="6" entity_filter="IsSelf">
 					<task class="HealSDX, SCore" OnStartAddBuffs="IsHealing" OnStopAddBuffs="buffProcessConsumables"/>
 					<consideration class="SelfHealthSDX, SCore" min="0.01" max="0.60"/>
@@ -772,27 +764,31 @@
 					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing"/>
 					<consideration class="SelfNotHasBuff, SCore" buffs="buffHealHealth,buffProcessConsumables,buffReload2,buffReloadDelay,buffReload3,buffHitStun"/>
 				</action>
+				<action name="Chat" weight="2" entity_filter="IsPlayer">
+					<task class="IdleSDX, SCore" /> 
+						<consideration class="EnemyNotNear, SCore" distance="20" />
+						<consideration class="TargetDistance" flip_x="true" min="1" max="3.5" curve="threshold" />
+				</action>
+				<action name="Stay" weight="2" entity_filter="IsSelf">
+					<task class="Guard, SCore"  /> 
+					<consideration class="EnemyNotNear, SCore" />
+					<consideration class="HasOrder, SCore" order="Stay"/>
+				</action>
+				<action name="Wander" weight="1" entity_filter="IsSelf">
+					<task class="WanderSDX, SCore"/>
+				</action>
+				<action name="DefaultAction" weight=".5" entity_filter="IsSelf">
+					<task class="IdleSDX, SCore" />
+				</action>
 			</ai_package>
 
 			<ai_package name="NPCModMechRangedBasic" entity_filter="IsEnemy" > 
-				 <action name="MoveToRandomTarget" weight="4" entity_filter="IsPlayer">
-                    <task class="MoveToInvestigate, SCore" run="true" />
-                    <consideration class="CanNotSeeTarget, SCore"/>
-					<consideration class="CanHearTarget, SCore" />
-					<consideration class="NotHasOrder, SCore" order="Stay" />
-                </action>	
-				<action name="MoveToEnemy" weight="4">
-					<task class="MoveToAttackTargetSDX, SCore" run="false" action_index="1" />
-					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
-					<consideration class="TargetVisible" />
-					<consideration class="NotHasOrder, SCore" order="Stay" />
-				</action>
 				<action name="RangedMeleeAttack" weight="6">
 					<task class="AttackTargetEntitySDX, SCore" action_index="0"/>
 					<consideration class="FailOnDistanceToLeader, SCore" max_distance="30"/>
 					<consideration class="InWeaponRange, SCore"  action_index="0"  /> 
 					<consideration class="TargetVisible" />
-					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing"/>	
+					<consideration class="SelfNotHasBuff, SCore" buffs="IsHealing"/>
 				</action>
 				<action name="RangedAttack" weight="5">
 					<task class="AttackTargetEntitySDX, SCore" action_index="1" />
@@ -801,7 +797,19 @@
 					<consideration class="InWeaponRange, SCore" action_index="1" />
 					<consideration class="SelfNotHasBuff, SCore" buffs="buffBurstDelay,IsHealing" /> 
 				</action>
-			</ai_package>	
+				<action name="MoveToRandomTarget" weight="4" entity_filter="IsPlayer">
+				   <task class="MoveToInvestigate, SCore" run="true" />
+				   <consideration class="CanNotSeeTarget, SCore"/>
+				   <consideration class="CanHearTarget, SCore" />
+				   <consideration class="NotHasOrder, SCore" order="Stay" />
+			   </action>
+			   <action name="MoveToEnemy" weight="4">
+				   <task class="MoveToAttackTargetSDX, SCore" run="false" action_index="1" />
+				   <consideration class="FailOnDistanceToLeader, SCore" max_distance="30" />
+				   <consideration class="TargetVisible" />
+				   <consideration class="NotHasOrder, SCore" order="Stay" />
+			   </action>
+			</ai_package>
 
 		</ai_packages>
 	</append>


### PR DESCRIPTION
I did not touch the order of considerations.

Also, there were quite a few whitespace changes, like changing spaces to tabs or removing whitespace at the end of lines. Those make the changes look more extensive than they really are, and can be ignored when looking at the merge request.